### PR TITLE
fix: changes test name for clarity

### DIFF
--- a/.github/workflows/ci-build-tests.yml
+++ b/.github/workflows/ci-build-tests.yml
@@ -61,7 +61,7 @@ jobs:
         uses: madrapps/jacoco-report@v1.6.1
         continue-on-error: true
         with:
-          paths: ${{ github.workspace }}/**/build/reports/jacoco/test/*.xml,
+          paths: ${{ github.workspace }}/**/build/reports/jacoco/test/*.xml
           token: ${{ secrets.GITHUB_TOKEN }}
           min-coverage-overall: 80
           min-coverage-changed-files: 80
@@ -73,6 +73,11 @@ jobs:
         run: |
           echo "Total coverage ${{ steps.jacoco.outputs.coverage-overall }}"
           echo "Changed Files coverage ${{ steps.jacoco.outputs.coverage-changed-files }}"
+      - name: Upload coverage reports to Codecov
+        uses: codecov/codecov-action@v4.0.1
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          slug: hywenklis/buddy-api
 
       - name: Create and push tag
         if: github.event_name == 'push' && contains(github.ref, 'refs/heads/')

--- a/src/test/java/com/buddy/api/integrations/web/pet/controller/CreatePetControllerTest.java
+++ b/src/test/java/com/buddy/api/integrations/web/pet/controller/CreatePetControllerTest.java
@@ -34,7 +34,7 @@ class CreatePetControllerTest extends IntegrationTestAbstract {
     }
 
     @Test
-    @DisplayName("Should return not found if the shelter id does not exists")
+    @DisplayName("Should return not found if the shelter id does not exists in the database")
     void should_return_not_found_shelterId_not_exists() throws Exception {
         var request = createPetRequest(UUID.randomUUID());
 

--- a/src/test/java/com/buddy/api/integrations/web/pet/controller/CreatePetControllerTest.java
+++ b/src/test/java/com/buddy/api/integrations/web/pet/controller/CreatePetControllerTest.java
@@ -34,9 +34,8 @@ class CreatePetControllerTest extends IntegrationTestAbstract {
     }
 
     @Test
-    @DisplayName("Should return not found return not found "
-            + "if there is no shelter id passed in the request")
-    void should_return_not_found() throws Exception {
+    @DisplayName("Should return not found if the shelter id does not exists")
+    void should_return_not_found_shelterId_not_exists() throws Exception {
         var request = createPetRequest(UUID.randomUUID());
 
         mockMvc


### PR DESCRIPTION
Verifiquei que o `@DisplayName` do método de testes `CreatePetControllerTest.should_return_not_found` estava com palavras duplicadas:
```java
    @Test
    @DisplayName("Should return not found return not found "
            + "if there is no shelter id passed in the request")
    void should_return_not_found() throws Exception {
        ...
    }
```

Inicialmente pensei em corrigir simplesmente retirando as palavras duplicadas, mas a minha primeira interpretação da frase "Should return not found if there is no shelter id passed in the request" é que a `API` deve retornar `NOT FOUND` quando o `shelterId` não foi informado no corpo da requisição, isso é, se o `shelterId` for nulo.

Estudando os testes entendi que era um caso diferente, pois já havia um teste para isso: `CreatePetControllerTest.should_return_bad_request_shelterId_not_filled`

Estudando a estrutura interna do `createPetRequest` entendi que o proposito do teste `should_return_not_found` era testar o caso em que o `shelterId` informado não existe na base de dados, o que não é obvio somente pelo nome do teste, seja pelo `@DisplayName`, seja pelo nome do método.

Assim, sugiro modificar o `@DisplayName` e o nome do método para: para:

```java
    @Test
    @DisplayName("Should return not found if the shelter id does not exists")
    void should_return_not_found_shelterId_not_exists() throws Exception {
        ...
    }
```