### PR TITLE
feat: makes pet avatar required

### DIFF
--- a/src/main/java/com/buddy/api/domains/pet/entities/PetEntity.java
+++ b/src/main/java/com/buddy/api/domains/pet/entities/PetEntity.java
@@ -44,6 +44,8 @@ public class PetEntity {
     private String location;
     private Double weight;
     private String description;
+
+    @Column(nullable = false)
     private String avatar;
 
     @OneToMany(mappedBy = "pet", cascade = CascadeType.ALL, orphanRemoval = true)

--- a/src/main/java/com/buddy/api/web/pets/requests/PetRequest.java
+++ b/src/main/java/com/buddy/api/web/pets/requests/PetRequest.java
@@ -35,7 +35,9 @@ public record PetRequest(
         @NotBlank(message = "Description of mandatory pet")
         String description,
 
+        @NotBlank(message = "Avatar of mandatory pet")
         String avatar,
+
         List<PetImageRequest> images,
 
         @NotNull(message = "ShelterId of mandatory pet")

--- a/src/test/java/com/buddy/api/integrations/web/pet/controller/CreatePetControllerTest.java
+++ b/src/test/java/com/buddy/api/integrations/web/pet/controller/CreatePetControllerTest.java
@@ -216,4 +216,32 @@ class CreatePetControllerTest extends IntegrationTestAbstract {
                 .andExpect(jsonPath("$.errors[0].errorCode").value(HttpStatus.BAD_REQUEST.value()))
                 .andExpect(jsonPath("$.errors[0].timestamp").isNotEmpty());
     }
+
+    @Test
+    @DisplayName("Should return bad request if avatar is not filled in")
+    void should_return_bad_request_avatar_not_filled() throws Exception {
+        var shelter = shelterComponent.createShelterNoPets();
+
+        var request = PetBuilder.createPetRequest(
+                randomAlphabetic(10),
+                randomAlphabetic(10),
+                randomAlphabetic(10),
+                Double.valueOf(randomNumeric(1)),
+                randomAlphabetic(10),
+                null,
+                List.of(),
+                shelter.getId()
+        );
+
+        mockMvc
+                .perform(post("/v1/pets/register")
+                        .contentType(APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.errors[0].field").value("avatar"))
+                .andExpect(jsonPath("$.errors[0].message").value("Avatar of mandatory pet"))
+                .andExpect(jsonPath("$.errors[0].httpStatus").value("BAD_REQUEST"))
+                .andExpect(jsonPath("$.errors[0].errorCode").value(HttpStatus.BAD_REQUEST.value()))
+                .andExpect(jsonPath("$.errors[0].timestamp").isNotEmpty());
+    }
 }


### PR DESCRIPTION
Acredito que pelo menos a imagem de  `avatar` do pet deveria ser obrigatória, para que os usuários buscando adotar um pet possam rapidamente ter uma primeira visão sobre o pet ao navegar na plataforma.

Coloquei uma validação `@NotBlank` no `PetRequest`, o que já seria suficiente para garantir que os pets cadastrados pela `API` tenham avatar.

Coloquei também `@Column(nullable = false)` no `PetEntity` para criar a `constraint de Not Null` no banco, mas caso já tenham pets sem avatar em produção seria necessário retirá-la ou pensar em uma estratégia para lidar com os pets já existentes.