### PR TITLE
feat: Adicionar configuração automática de Checkstyle para IntelliJ IDEA

### DIFF
--- a/CHECKSTYLE_SETUP.md
+++ b/CHECKSTYLE_SETUP.md
@@ -1,0 +1,53 @@
+# Configuração do Checkstyle (IMPORTANTE)
+
+Para garantir que todos os colaboradores utilizem as mesmas regras de formatação e verificação de código, configure o Checkstyle no IntelliJ IDEA seguindo as instruções abaixo.
+
+## Passo 1: Instalar o Plugin Checkstyle-IDEA
+
+1. Abra o IntelliJ IDEA.
+2. Vá para `File > Settings > Plugins` (ou `Preferences > Plugins` no macOS).
+3. Busque por "Checkstyle-IDEA" e instale o plugin.
+4. Reinicie o IntelliJ IDEA, se necessário.
+
+## Passo 2: Executar o Script de Configuração
+
+### Linux e macOS:
+
+1. Abra um terminal.
+2. Navegue até o diretório do projeto.
+3. Execute o seguinte comando:
+
+    ```bash
+    ./setup.sh
+    ```
+
+### Windows:
+
+1. Abra o Prompt de Comando.
+2. Navegue até o diretório do projeto.
+3. Execute o seguinte comando:
+
+    ```batch
+    setup.bat
+    ```
+
+Esses scripts irão criar automaticamente a configuração do Checkstyle no IntelliJ IDEA, apontando para o arquivo de configuração localizado em `config/checkstyle/checkstyle.xml`.
+
+## Passo 3: Configurar o Checkstyle no IntelliJ IDEA
+
+1. No IntelliJ IDEA, vá para `File > Settings > Tools > Checkstyle` (ou `Preferences > Tools > Checkstyle` no macOS).
+2. Verifique se a configuração do Checkstyle está apontando para o arquivo `config/checkstyle/checkstyle.xml`. A configuração deve ter sido criada automaticamente pelo script.
+3. Clique em "OK" para salvar as configurações.
+
+## Passo 4: Verificar e Corrigir o Código
+
+1. Para verificar o código com o Checkstyle, vá para `Code > Analyze Code > Checkstyle > Check Whole Project`.
+2. Corrija quaisquer violações de estilo de acordo com as regras definidas.
+
+Seguindo esses passos, você garantirá que o código esteja sempre em conformidade com as regras de formatação e estilo definidas pelo projeto.
+
+## Importante
+
+Lembre-se de executar o script de configuração (`setup.sh` ou `setup.bat`) sempre que clonar o repositório ou fizer uma nova configuração do ambiente de desenvolvimento.
+
+Se tiver dúvidas ou encontrar problemas, consulte a documentação do plugin Checkstyle-IDEA ou entre em contato com o administrador do projeto.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -16,6 +16,7 @@ Contribuições são bem-vindas! Siga os passos abaixo para contribuir:
      git clone https://github.com/<SEU_USUARIO>/buddy-backend.git
      ```
      *Substitua `<SEU_USUARIO>` pelo seu nome de usuário no GitHub.*
+   - > **Importante** [Configurando CheckStyle no projeto](CHECKSTYLE_SETUP.md)
 
 3. **Tipos de branches:**
    - **main:** *Branch principal do projeto, onde o código estável é armazenado.*

--- a/config/checkstyle/xsl/checkstyle-custom.xsl
+++ b/config/checkstyle/xsl/checkstyle-custom.xsl
@@ -1,6 +1,6 @@
 <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="1.0">
     <xsl:output method="html" indent="yes"/>
-    <xsl:decimal-format decimal-separator="." grouping-separator=","/>
+    <xsl:decimal-format/>
     <!--
     Checkstyle XML Style Sheet by Daniel Grenner
     <daniel DOT grenner AT enea DOT se>

--- a/config/setup/setup.bat
+++ b/config/setup/setup.bat
@@ -1,0 +1,15 @@
+@echo off
+
+REM Cria o diretório .idea se não existir
+if not exist .idea mkdir .idea
+
+REM Cria o arquivo de configuração do Checkstyle no IntelliJ IDEA
+echo ^<component name="CheckStyle-IDEA"^> > .idea\checkstyle-idea.xml
+echo ^    ^<option name="configuration"^> >> .idea\checkstyle-idea.xml
+echo ^        ^<list^> >> .idea\checkstyle-idea.xml
+echo ^            ^<option name="Local file" value="%%PROJECT_DIR%%/config/checkstyle/checkstyle.xml" /^> >> .idea\checkstyle-idea.xml
+echo ^        ^</list^> >> .idea\checkstyle-idea.xml
+echo ^    ^</option^> >> .idea\checkstyle-idea.xml
+echo ^</component^> >> .idea\checkstyle-idea.xml
+
+echo Checkstyle configurado no IntelliJ IDEA.

--- a/config/setup/setup.sh
+++ b/config/setup/setup.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+# Cria o arquivo de configuração do Checkstyle no IntelliJ IDEA
+mkdir -p .idea
+
+cat <<EOT > .idea/checkstyle-idea.xml
+<component name="CheckStyle-IDEA">
+    <option name="configuration">
+        <list>
+            <option name="Local file" value="\$PROJECT_DIR\$/config/checkstyle/checkstyle.xml" />
+        </list>
+    </option>
+</component>
+EOT
+
+echo "Checkstyle configurado no IntelliJ IDEA."

--- a/intellij-checkstyle-config.xml
+++ b/intellij-checkstyle-config.xml
@@ -1,0 +1,7 @@
+<component name="CheckStyle-IDEA">
+    <option name="configuration">
+        <list>
+            <option name="Local file" value="$PROJECT_DIR$/config/checkstyle/checkstyle.xml" />
+        </list>
+    </option>
+</component>


### PR DESCRIPTION
### Resumo

Esta PR adiciona scripts e instruções para automatizar o processo de configuração do Checkstyle para todos os colaboradores que usam o IntelliJ IDEA. As mudanças incluem:

- `setup.sh`: Um script para Linux e macOS para configurar o Checkstyle no IntelliJ IDEA.
- `setup.bat`: Um script para Windows para configurar o Checkstyle no IntelliJ IDEA.
- `CHECKSTYLE_SETUP.md`: Um arquivo markdown com instruções detalhadas para configurar o Checkstyle.
- Atualização do `README.md` para referenciar as novas instruções de configuração do Checkstyle.

### Propósito

Essas mudanças garantem que todos os colaboradores usem automaticamente as mesmas regras do Checkstyle, promovendo um estilo de código e qualidade consistentes em todo o projeto.

### Notas Adicionais

Certifique-se de que os scripts tenham as permissões apropriadas para execução (`chmod +x setup.sh` para sistemas Unix).