### PR TITLE
Fix: corrigir mensagens de validação para ShelterRequest e PetRequest

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE/pull_request_template.md
+++ b/.github/PULL_REQUEST_TEMPLATE/pull_request_template.md
@@ -1,0 +1,25 @@
+## Descrição
+<!-- Descreva brevemente o que foi feito nesta pull request e o motivo das mudanças. -->
+
+### O que foi feito:
+- <!-- Descreva as principais alterações realizadas. -->
+
+### Por que foi feito:
+- <!-- Explique por que essas alterações são necessárias. -->
+
+## Tipos de mudanças
+<!-- Marque com um "x" as opções que se aplicam. -->
+- [ ] Correção de bug (mudança que corrige uma issue)
+- [ ] Nova funcionalidade (mudança que adiciona uma nova funcionalidade)
+- [ ] Refatoração (melhoria de código que não altera o comportamento do sistema)
+- [ ] Alteração de documentação
+
+## Checklist
+<!-- Verifique se seu pull request segue as boas práticas listadas abaixo e marque as caixas. -->
+- [ ] O código segue o padrão de estilo e boas práticas do projeto.
+- [ ] Eu fiz uma revisão manual do código.
+- [ ] Testes foram escritos ou ajustados para cobrir as mudanças.
+- [ ] A documentação foi atualizada, se necessário.
+
+## Outras informações
+<!-- Adicione qualquer outra informação relevante aqui. -->

--- a/src/main/java/com/buddy/api/web/pets/controllers/CreatePetController.java
+++ b/src/main/java/com/buddy/api/web/pets/controllers/CreatePetController.java
@@ -1,5 +1,6 @@
 package com.buddy.api.web.pets.controllers;
 
+import com.buddy.api.domains.pet.dtos.PetDto;
 import com.buddy.api.domains.pet.services.CreatePet;
 import com.buddy.api.web.pets.mappers.PetMapperRequest;
 import com.buddy.api.web.pets.mappers.PetMapperResponse;
@@ -33,7 +34,8 @@ public class CreatePetController {
         description = "Register pet with their appropriate information"
     )
     public PetResponse registration(@RequestBody @Valid final PetRequest petRequest) {
-        service.create(mapperRequest.mapToDto(petRequest));
+        PetDto petDto = mapperRequest.mapToDto(petRequest);
+        service.create(petDto);
         return mapperResponse.mapToResponse();
     }
 }

--- a/src/main/java/com/buddy/api/web/pets/requests/PetRequest.java
+++ b/src/main/java/com/buddy/api/web/pets/requests/PetRequest.java
@@ -14,11 +14,11 @@ public record PetRequest(@Schema(description = "Name of the pet", example = "Bud
                          String name,
 
                          @Schema(description = "Species of the pet",
-                                 example = "Dog, Cat, Bird, Fish, Reptile")
+                                 example = "Cachorro, Gato, Pássaro, Peixe, Réptil")
                          @NotBlank(message = "Pet species is mandatory")
                          String specie,
 
-                         @Schema(description = "Gender of the pet", example = "Male, Female")
+                         @Schema(description = "Gender of the pet", example = "Macho, Fêmea")
                          @NotBlank(message = "Pet gender is mandatory")
                          String gender,
 

--- a/src/main/java/com/buddy/api/web/pets/requests/PetRequest.java
+++ b/src/main/java/com/buddy/api/web/pets/requests/PetRequest.java
@@ -9,36 +9,35 @@ import java.util.UUID;
 import lombok.Builder;
 
 @Builder
-public record PetRequest(
-    @Schema(description = "Name of the pet", example = "Buddy")
-    @NotBlank(message = "Name of mandatory pet")
-    String name,
+public record PetRequest(@Schema(description = "Name of the pet", example = "Buddy")
+                         @NotBlank(message = "Pet name is mandatory")
+                         String name,
 
-    @Schema(description = "Species of the pet",
-        example = "Cachorro, Gato, Pássaro, Peixe, Réptil")
-    @NotBlank(message = "Specie of mandatory pet")
-    String specie,
+                         @Schema(description = "Species of the pet",
+                                 example = "Dog, Cat, Bird, Fish, Reptile")
+                         @NotBlank(message = "Pet species is mandatory")
+                         String specie,
 
-    @Schema(description = "Gender of the pet", example = "Macho, Fêmea")
-    @NotBlank(message = "Gender of mandatory pet")
-    String gender,
+                         @Schema(description = "Gender of the pet", example = "Male, Female")
+                         @NotBlank(message = "Pet gender is mandatory")
+                         String gender,
 
-    @Schema(description = "Birth date of the pet", example = "2021-01-01")
-    LocalDate birthDate,
+                         @Schema(description = "Birth date of the pet", example = "2021-01-01")
+                         LocalDate birthDate,
 
-    @Schema(description = "Location of the pet", example = "Maceió, Alagoas")
-    String location,
+                         @Schema(description = "Location of the pet", example = "Maceió, Alagoas")
+                         String location,
 
-    @NotNull(message = "Weight of mandatory pet")
-    Double weight,
+                         @NotNull(message = "Pet weight is mandatory")
+                         Double weight,
 
-    @NotBlank(message = "Description of mandatory pet")
-    String description,
+                         @NotBlank(message = "Pet description is mandatory")
+                         String description,
 
-    String avatar,
-    List<PetImageRequest> images,
+                         String avatar,
+                         List<PetImageRequest> images,
 
-    @NotNull(message = "ShelterId of mandatory pet")
-    UUID shelterId
+                         @NotNull(message = "Shelter ID is mandatory")
+                         UUID shelterId
 ) {
 }

--- a/src/main/java/com/buddy/api/web/pets/requests/PetRequest.java
+++ b/src/main/java/com/buddy/api/web/pets/requests/PetRequest.java
@@ -3,6 +3,8 @@ package com.buddy.api.web.pets.requests;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.PastOrPresent;
+import jakarta.validation.constraints.Pattern;
 import java.time.LocalDate;
 import java.util.List;
 import java.util.UUID;
@@ -14,7 +16,7 @@ public record PetRequest(@Schema(description = "Name of the pet", example = "Bud
                          String name,
 
                          @Schema(description = "Species of the pet",
-                                 example = "Cachorro, Gato, Pássaro, Peixe, Réptil")
+                             example = "Cachorro, Gato, Pássaro, Peixe, Réptil")
                          @NotBlank(message = "Pet species is mandatory")
                          String specie,
 
@@ -23,9 +25,14 @@ public record PetRequest(@Schema(description = "Name of the pet", example = "Bud
                          String gender,
 
                          @Schema(description = "Birth date of the pet", example = "2021-01-01")
+                         @PastOrPresent(message = "Birth date must be in the past or present")
                          LocalDate birthDate,
 
                          @Schema(description = "Location of the pet", example = "Maceió, Alagoas")
+                         @Pattern(
+                             regexp = "^[a-zA-Z,\\s]+$",
+                             message = "Location must be a valid city and state"
+                         )
                          String location,
 
                          @NotNull(message = "Pet weight is mandatory")

--- a/src/main/java/com/buddy/api/web/shelter/requests/ShelterRequest.java
+++ b/src/main/java/com/buddy/api/web/shelter/requests/ShelterRequest.java
@@ -16,12 +16,12 @@ public record ShelterRequest(@NotBlank(message = "Shelter name is mandatory")
                              @NotBlank(message = "Responsible person's name is mandatory")
                              String nameResponsible,
 
-                             @CPF
+                             @CPF(message = "Invalid CPF format")
                              @Unique(value = CPF, message = "CPF must be unique")
                              @NotBlank(message = "Responsible person's CPF is mandatory")
                              String cpfResponsible,
 
-                             @Email
+                             @Email(message = "Invalid email format")
                              @Unique(value = EMAIL, message = "Email must be unique")
                              @NotBlank(message = "Email is mandatory")
                              String email,

--- a/src/main/java/com/buddy/api/web/shelter/requests/ShelterRequest.java
+++ b/src/main/java/com/buddy/api/web/shelter/requests/ShelterRequest.java
@@ -10,22 +10,23 @@ import lombok.Builder;
 import org.hibernate.validator.constraints.br.CPF;
 
 @Builder
-public record ShelterRequest(@NotBlank(message = "Name of mandatory shelter")
+public record ShelterRequest(@NotBlank(message = "Shelter name is mandatory")
                              String nameShelter,
 
-                             @NotBlank(message = "Responsible for the mandatory shelter")
+                             @NotBlank(message = "Responsible person's name is mandatory")
                              String nameResponsible,
 
                              @CPF
                              @Unique(value = CPF, message = "CPF must be unique")
-                             @NotBlank(message = "Mandatory responsible person's CPF")
+                             @NotBlank(message = "Responsible person's CPF is mandatory")
                              String cpfResponsible,
 
                              @Email
-                             @Unique(value = EMAIL, message = "EMAIL must be unique")
-                             @NotBlank(message = "Mandatory EMAIL")
+                             @Unique(value = EMAIL, message = "Email must be unique")
+                             @NotBlank(message = "Email is mandatory")
                              String email,
 
-                             @NotBlank(message = "Avatar for the mandatory shelter")
-                             String avatar) {
+                             @NotBlank(message = "Shelter avatar is mandatory")
+                             String avatar
+) {
 }

--- a/src/test/java/com/buddy/api/integrations/web/pet/controller/CreatePetControllerTest.java
+++ b/src/test/java/com/buddy/api/integrations/web/pet/controller/CreatePetControllerTest.java
@@ -79,7 +79,7 @@ class CreatePetControllerTest extends IntegrationTestAbstract {
                 .content(objectMapper.writeValueAsString(request)))
             .andExpect(status().isBadRequest())
             .andExpect(jsonPath(ERROR_FIELD_PATH).value("name"))
-            .andExpect(jsonPath(ERROR_MESSAGE_PATH).value("Name of mandatory pet"))
+            .andExpect(jsonPath(ERROR_MESSAGE_PATH).value("Pet name is mandatory"))
             .andExpect(jsonPath(ERROR_HTTP_STATUS_PATH).value(HttpStatus.BAD_REQUEST.name()))
             .andExpect(jsonPath(ERROR_CODE_PATH).value(HttpStatus.BAD_REQUEST.value()))
             .andExpect(jsonPath(ERROR_TIMESTAMP_PATH).isNotEmpty());
@@ -107,7 +107,7 @@ class CreatePetControllerTest extends IntegrationTestAbstract {
                 .content(objectMapper.writeValueAsString(request)))
             .andExpect(status().isBadRequest())
             .andExpect(jsonPath(ERROR_FIELD_PATH).value("specie"))
-            .andExpect(jsonPath(ERROR_MESSAGE_PATH).value("Specie of mandatory pet"))
+            .andExpect(jsonPath(ERROR_MESSAGE_PATH).value("Pet species is mandatory"))
             .andExpect(jsonPath(ERROR_HTTP_STATUS_PATH).value(HttpStatus.BAD_REQUEST.name()))
             .andExpect(jsonPath(ERROR_CODE_PATH).value(HttpStatus.BAD_REQUEST.value()))
             .andExpect(jsonPath(ERROR_TIMESTAMP_PATH).isNotEmpty());
@@ -135,7 +135,7 @@ class CreatePetControllerTest extends IntegrationTestAbstract {
                 .content(objectMapper.writeValueAsString(request)))
             .andExpect(status().isBadRequest())
             .andExpect(jsonPath(ERROR_FIELD_PATH).value("gender"))
-            .andExpect(jsonPath(ERROR_MESSAGE_PATH).value("Gender of mandatory pet"))
+            .andExpect(jsonPath(ERROR_MESSAGE_PATH).value("Pet gender is mandatory"))
             .andExpect(jsonPath(ERROR_HTTP_STATUS_PATH).value(HttpStatus.BAD_REQUEST.name()))
             .andExpect(jsonPath(ERROR_CODE_PATH).value(HttpStatus.BAD_REQUEST.value()))
             .andExpect(jsonPath(ERROR_TIMESTAMP_PATH).isNotEmpty());
@@ -163,7 +163,7 @@ class CreatePetControllerTest extends IntegrationTestAbstract {
                 .content(objectMapper.writeValueAsString(request)))
             .andExpect(status().isBadRequest())
             .andExpect(jsonPath(ERROR_FIELD_PATH).value("weight"))
-            .andExpect(jsonPath(ERROR_MESSAGE_PATH).value("Weight of mandatory pet"))
+            .andExpect(jsonPath(ERROR_MESSAGE_PATH).value("Pet weight is mandatory"))
             .andExpect(jsonPath(ERROR_HTTP_STATUS_PATH).value(HttpStatus.BAD_REQUEST.name()))
             .andExpect(jsonPath(ERROR_CODE_PATH).value(HttpStatus.BAD_REQUEST.value()))
             .andExpect(jsonPath(ERROR_TIMESTAMP_PATH).isNotEmpty());
@@ -191,7 +191,7 @@ class CreatePetControllerTest extends IntegrationTestAbstract {
                 .content(objectMapper.writeValueAsString(request)))
             .andExpect(status().isBadRequest())
             .andExpect(jsonPath(ERROR_FIELD_PATH).value("description"))
-            .andExpect(jsonPath(ERROR_MESSAGE_PATH).value("Description of mandatory pet"))
+            .andExpect(jsonPath(ERROR_MESSAGE_PATH).value("Pet description is mandatory"))
             .andExpect(jsonPath(ERROR_HTTP_STATUS_PATH).value(HttpStatus.BAD_REQUEST.name()))
             .andExpect(jsonPath(ERROR_CODE_PATH).value(HttpStatus.BAD_REQUEST.value()))
             .andExpect(jsonPath(ERROR_TIMESTAMP_PATH).isNotEmpty());
@@ -217,7 +217,7 @@ class CreatePetControllerTest extends IntegrationTestAbstract {
                 .content(objectMapper.writeValueAsString(request)))
             .andExpect(status().isBadRequest())
             .andExpect(jsonPath(ERROR_FIELD_PATH).value("shelterId"))
-            .andExpect(jsonPath(ERROR_MESSAGE_PATH).value("ShelterId of mandatory pet"))
+            .andExpect(jsonPath(ERROR_MESSAGE_PATH).value("Shelter ID is mandatory"))
             .andExpect(jsonPath(ERROR_HTTP_STATUS_PATH).value(HttpStatus.BAD_REQUEST.name()))
             .andExpect(jsonPath(ERROR_CODE_PATH).value(HttpStatus.BAD_REQUEST.value()))
             .andExpect(jsonPath(ERROR_TIMESTAMP_PATH).isNotEmpty());

--- a/src/test/java/com/buddy/api/integrations/web/shelter/controller/CreateShelterControllerTest.java
+++ b/src/test/java/com/buddy/api/integrations/web/shelter/controller/CreateShelterControllerTest.java
@@ -88,7 +88,7 @@ class CreateShelterControllerTest extends IntegrationTestAbstract {
                 .content(objectMapper.writeValueAsString(request)))
             .andExpect(status().isBadRequest())
             .andExpect(jsonPath(ERROR_FIELD_PATH).value("email"))
-            .andExpect(jsonPath(ERROR_MESSAGE_PATH).value("EMAIL must be unique"))
+            .andExpect(jsonPath(ERROR_MESSAGE_PATH).value("Email must be unique"))
             .andExpect(jsonPath(ERROR_HTTP_STATUS_PATH).value(HttpStatus.BAD_REQUEST.name()))
             .andExpect(jsonPath(ERROR_CODE_PATH).value(HttpStatus.BAD_REQUEST.value()))
             .andExpect(jsonPath(ERROR_TIMESTAMP_PATH).isNotEmpty());
@@ -111,7 +111,7 @@ class CreateShelterControllerTest extends IntegrationTestAbstract {
                 .content(objectMapper.writeValueAsString(request)))
             .andExpect(status().isBadRequest())
             .andExpect(jsonPath(ERROR_FIELD_PATH).value("nameShelter"))
-            .andExpect(jsonPath(ERROR_MESSAGE_PATH).value("Name of mandatory shelter"))
+            .andExpect(jsonPath(ERROR_MESSAGE_PATH).value("Shelter name is mandatory"))
             .andExpect(jsonPath(ERROR_HTTP_STATUS_PATH).value(HttpStatus.BAD_REQUEST.name()))
             .andExpect(jsonPath(ERROR_CODE_PATH).value(HttpStatus.BAD_REQUEST.value()))
             .andExpect(jsonPath(ERROR_TIMESTAMP_PATH).isNotEmpty());
@@ -136,7 +136,7 @@ class CreateShelterControllerTest extends IntegrationTestAbstract {
             .andExpect(jsonPath(ERROR_FIELD_PATH)
                 .value("nameResponsible"))
             .andExpect(jsonPath(ERROR_MESSAGE_PATH)
-                .value("Responsible for the mandatory shelter"))
+                .value("Responsible person's name is mandatory"))
             .andExpect(jsonPath(ERROR_HTTP_STATUS_PATH).value(HttpStatus.BAD_REQUEST.name()))
             .andExpect(jsonPath(ERROR_CODE_PATH).value(HttpStatus.BAD_REQUEST.value()))
             .andExpect(jsonPath(ERROR_TIMESTAMP_PATH).isNotEmpty());
@@ -159,7 +159,7 @@ class CreateShelterControllerTest extends IntegrationTestAbstract {
                 .content(objectMapper.writeValueAsString(request)))
             .andExpect(status().isBadRequest())
             .andExpect(jsonPath(ERROR_FIELD_PATH).value("cpfResponsible"))
-            .andExpect(jsonPath(ERROR_MESSAGE_PATH).value("Mandatory responsible person's CPF"))
+            .andExpect(jsonPath(ERROR_MESSAGE_PATH).value("Responsible person's CPF is mandatory"))
             .andExpect(jsonPath(ERROR_HTTP_STATUS_PATH).value(HttpStatus.BAD_REQUEST.name()))
             .andExpect(jsonPath(ERROR_CODE_PATH).value(HttpStatus.BAD_REQUEST.value()))
             .andExpect(jsonPath(ERROR_TIMESTAMP_PATH).isNotEmpty());
@@ -182,7 +182,7 @@ class CreateShelterControllerTest extends IntegrationTestAbstract {
                 .content(objectMapper.writeValueAsString(request)))
             .andExpect(status().isBadRequest())
             .andExpect(jsonPath(ERROR_FIELD_PATH).value("email"))
-            .andExpect(jsonPath(ERROR_MESSAGE_PATH).value("Mandatory EMAIL"))
+            .andExpect(jsonPath(ERROR_MESSAGE_PATH).value("Email is mandatory"))
             .andExpect(jsonPath(ERROR_HTTP_STATUS_PATH).value(HttpStatus.BAD_REQUEST.name()))
             .andExpect(jsonPath(ERROR_CODE_PATH).value(HttpStatus.BAD_REQUEST.value()))
             .andExpect(jsonPath(ERROR_TIMESTAMP_PATH).isNotEmpty());

--- a/src/test/java/com/buddy/api/integrations/web/shelter/controller/CreateShelterControllerTest.java
+++ b/src/test/java/com/buddy/api/integrations/web/shelter/controller/CreateShelterControllerTest.java
@@ -166,6 +166,29 @@ class CreateShelterControllerTest extends IntegrationTestAbstract {
     }
 
     @Test
+    @DisplayName("Should return bad request if cpfResponsible is invalid format")
+    void should_return_bad_request_cpf_responsible_is_invalid_format() throws Exception {
+        var request = createShelterRequest(
+            randomAlphabetic(10),
+            randomAlphabetic(10),
+            randomAlphabetic(10),
+            generateValidEmail(),
+            randomAlphabetic(10)
+        );
+
+        mockMvc
+            .perform(post(SHELTER_REGISTER_URL)
+                .contentType(APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(request)))
+            .andExpect(status().isBadRequest())
+            .andExpect(jsonPath(ERROR_FIELD_PATH).value("cpfResponsible"))
+            .andExpect(jsonPath(ERROR_MESSAGE_PATH).value("Invalid CPF format"))
+            .andExpect(jsonPath(ERROR_HTTP_STATUS_PATH).value(HttpStatus.BAD_REQUEST.name()))
+            .andExpect(jsonPath(ERROR_CODE_PATH).value(HttpStatus.BAD_REQUEST.value()))
+            .andExpect(jsonPath(ERROR_TIMESTAMP_PATH).isNotEmpty());
+    }
+
+    @Test
     @DisplayName("Should return bad request if email is not filled in")
     void should_return_bad_request_email_not_filled() throws Exception {
         var request = createShelterRequest(
@@ -183,6 +206,29 @@ class CreateShelterControllerTest extends IntegrationTestAbstract {
             .andExpect(status().isBadRequest())
             .andExpect(jsonPath(ERROR_FIELD_PATH).value("email"))
             .andExpect(jsonPath(ERROR_MESSAGE_PATH).value("Email is mandatory"))
+            .andExpect(jsonPath(ERROR_HTTP_STATUS_PATH).value(HttpStatus.BAD_REQUEST.name()))
+            .andExpect(jsonPath(ERROR_CODE_PATH).value(HttpStatus.BAD_REQUEST.value()))
+            .andExpect(jsonPath(ERROR_TIMESTAMP_PATH).isNotEmpty());
+    }
+
+    @Test
+    @DisplayName("Should return bad request if email is invalid format")
+    void should_return_bad_request_email_is_invalid_format() throws Exception {
+        var request = createShelterRequest(
+            randomAlphabetic(10),
+            randomAlphabetic(10),
+            generateValidCpf(),
+            randomAlphabetic(10),
+            randomAlphabetic(10)
+        );
+
+        mockMvc
+            .perform(post(SHELTER_REGISTER_URL)
+                .contentType(APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(request)))
+            .andExpect(status().isBadRequest())
+            .andExpect(jsonPath(ERROR_FIELD_PATH).value("email"))
+            .andExpect(jsonPath(ERROR_MESSAGE_PATH).value("Invalid email format"))
             .andExpect(jsonPath(ERROR_HTTP_STATUS_PATH).value(HttpStatus.BAD_REQUEST.name()))
             .andExpect(jsonPath(ERROR_CODE_PATH).value(HttpStatus.BAD_REQUEST.value()))
             .andExpect(jsonPath(ERROR_TIMESTAMP_PATH).isNotEmpty());


### PR DESCRIPTION
## Descrição
- Esta pull request corrige as mensagens de validação nas classes ShelterRequest e PetRequest. Foram feitos ajustes nas mensagens em inglês para garantir que estejam semanticamente corretas e claras para o usuário final.

### O que foi feito:
- Correção das mensagens de validação nas classes ShelterRequest e PetRequest.
- As mensagens agora utilizam uma linguagem mais clara e adequada em inglês.

### Por que foi feito:
- As mensagens anteriores possuíam erros gramaticais e de semântica, o que poderia causar confusão para usuários que falam inglês. Esta alteração garante uma melhor experiência de usuário.
- https://github.com/hywenklis/buddy-api/issues/81 

## Tipos de mudanças
- [ ] Correção de bug (mudança que corrige uma issue)
- [ ] Nova funcionalidade (mudança que adiciona uma nova funcionalidade)
- [x] Refatoração (melhoria de código que não altera o comportamento do sistema)
- [ ] Alteração de documentação

## Checklist
- [x] O código segue o padrão de estilo e boas práticas do projeto.
- [x] Eu fiz uma revisão manual do código.
- [x] Testes foram escritos ou ajustados para cobrir as mudanças.
- [x] A documentação foi atualizada, se necessário.

## Outras informações
