### PR TITLE
feature: email treatment

### DIFF
--- a/src/main/java/com/buddy/api/commons/exceptions/InvalidEmailAddressException.java
+++ b/src/main/java/com/buddy/api/commons/exceptions/InvalidEmailAddressException.java
@@ -1,0 +1,13 @@
+package com.buddy.api.commons.exceptions;
+
+import java.io.Serial;
+import org.springframework.http.HttpStatus;
+
+public class InvalidEmailAddressException extends DomainException {
+    @Serial
+    private static final long serialVersionUID = 4067260310533491061L;
+
+    public InvalidEmailAddressException(final String message) {
+        super(message, "email", HttpStatus.BAD_REQUEST);
+    }
+}

--- a/src/main/java/com/buddy/api/domains/account/dtos/AccountDto.java
+++ b/src/main/java/com/buddy/api/domains/account/dtos/AccountDto.java
@@ -1,8 +1,9 @@
 package com.buddy.api.domains.account.dtos;
 
 import com.buddy.api.domains.account.entities.AccountEntity;
+import com.buddy.api.domains.valueobjects.EmailAddress;
 
-public record AccountDto(String email,
+public record AccountDto(EmailAddress email,
                          String phoneNumber,
                          String password,
                          Boolean termsOfUserConsent) {

--- a/src/main/java/com/buddy/api/domains/account/dtos/AccountDto.java
+++ b/src/main/java/com/buddy/api/domains/account/dtos/AccountDto.java
@@ -2,7 +2,9 @@ package com.buddy.api.domains.account.dtos;
 
 import com.buddy.api.domains.account.entities.AccountEntity;
 import com.buddy.api.domains.valueobjects.EmailAddress;
+import lombok.Builder;
 
+@Builder
 public record AccountDto(EmailAddress email,
                          String phoneNumber,
                          String password,

--- a/src/main/java/com/buddy/api/domains/account/entities/AccountEntity.java
+++ b/src/main/java/com/buddy/api/domains/account/entities/AccountEntity.java
@@ -1,6 +1,8 @@
 package com.buddy.api.domains.account.entities;
 
+import com.buddy.api.domains.valueobjects.EmailAddress;
 import jakarta.persistence.Column;
+import jakarta.persistence.Embedded;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
@@ -31,8 +33,9 @@ public class AccountEntity {
     @Column(name = "account_id", nullable = false, unique = true)
     private UUID accountId;
 
-    @Column(name = "email", nullable = false, unique = true)
-    private String email;
+    @Column
+    @Embedded
+    private EmailAddress email;
 
     @Column(name = "phone_number")
     private String phoneNumber;

--- a/src/main/java/com/buddy/api/domains/account/repository/AccountRepository.java
+++ b/src/main/java/com/buddy/api/domains/account/repository/AccountRepository.java
@@ -1,11 +1,12 @@
 package com.buddy.api.domains.account.repository;
 
 import com.buddy.api.domains.account.entities.AccountEntity;
+import com.buddy.api.domains.valueobjects.EmailAddress;
 import java.util.UUID;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public interface AccountRepository extends JpaRepository<AccountEntity, UUID> {
-    Boolean existsByEmail(final String email);
+    Boolean existsByEmail(final EmailAddress email);
 }

--- a/src/main/java/com/buddy/api/domains/account/services/impl/CreateAccountServiceImpl.java
+++ b/src/main/java/com/buddy/api/domains/account/services/impl/CreateAccountServiceImpl.java
@@ -4,6 +4,7 @@ import com.buddy.api.commons.exceptions.EmailAlreadyRegisteredException;
 import com.buddy.api.domains.account.dtos.AccountDto;
 import com.buddy.api.domains.account.repository.AccountRepository;
 import com.buddy.api.domains.account.services.CreateAccountService;
+import com.buddy.api.domains.valueobjects.EmailAddress;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.crypto.password.PasswordEncoder;
@@ -26,7 +27,7 @@ public class CreateAccountServiceImpl implements CreateAccountService {
         accountRepository.save(accountEntity);
     }
 
-    private void validateEmailIsNotRegistered(final String email) {
+    private void validateEmailIsNotRegistered(final EmailAddress email) {
         if (accountRepository.existsByEmail(email)) {
             throw new EmailAlreadyRegisteredException("Account email already registered", "email");
         }

--- a/src/main/java/com/buddy/api/domains/valueobjects/EmailAddress.java
+++ b/src/main/java/com/buddy/api/domains/valueobjects/EmailAddress.java
@@ -15,9 +15,9 @@ public record EmailAddress(
     }
 
     public EmailAddress {
-        if (value == null || value.isEmpty()) {
-            throw new InvalidEmailAddressException("Email address value cannot be null or empty");
+        if (value == null || value.isBlank()) {
+            throw new InvalidEmailAddressException("Email address value cannot be null or blank");
         }
-        value = value.toLowerCase(Locale.ENGLISH);
+        value = value.trim().toLowerCase(Locale.ENGLISH);
     }
 }

--- a/src/main/java/com/buddy/api/domains/valueobjects/EmailAddress.java
+++ b/src/main/java/com/buddy/api/domains/valueobjects/EmailAddress.java
@@ -1,5 +1,6 @@
 package com.buddy.api.domains.valueobjects;
 
+import com.buddy.api.commons.exceptions.InvalidEmailAddressException;
 import jakarta.persistence.Column;
 import jakarta.persistence.Embeddable;
 import java.util.Locale;
@@ -9,11 +10,14 @@ public record EmailAddress(
     @Column(name = "email", nullable = false, unique = true)
     String value
 ) {
-    public EmailAddress() {
+    private EmailAddress() {
         this("");
     }
 
     public EmailAddress {
-        value = (value == null) ? "" : value.toLowerCase(Locale.ENGLISH);
+        if (value == null || value.isEmpty()) {
+            throw new InvalidEmailAddressException("Email address value cannot be null or empty");
+        }
+        value = value.toLowerCase(Locale.ENGLISH);
     }
 }

--- a/src/main/java/com/buddy/api/domains/valueobjects/EmailAddress.java
+++ b/src/main/java/com/buddy/api/domains/valueobjects/EmailAddress.java
@@ -2,17 +2,12 @@ package com.buddy.api.domains.valueobjects;
 
 import com.buddy.api.commons.exceptions.InvalidEmailAddressException;
 import jakarta.persistence.Column;
-import jakarta.persistence.Embeddable;
 import java.util.Locale;
 
-@Embeddable
 public record EmailAddress(
     @Column(name = "email", nullable = false, unique = true)
     String value
 ) {
-    private EmailAddress() {
-        this("");
-    }
 
     public EmailAddress {
         if (value == null || value.isBlank()) {

--- a/src/main/java/com/buddy/api/domains/valueobjects/EmailAddress.java
+++ b/src/main/java/com/buddy/api/domains/valueobjects/EmailAddress.java
@@ -1,0 +1,19 @@
+package com.buddy.api.domains.valueobjects;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Embeddable;
+import java.util.Locale;
+
+@Embeddable
+public record EmailAddress(
+    @Column(name = "email", nullable = false, unique = true)
+    String value
+) {
+    public EmailAddress() {
+        this("");
+    }
+
+    public EmailAddress {
+        value = (value == null) ? "" : value.toLowerCase(Locale.ENGLISH);
+    }
+}

--- a/src/main/java/com/buddy/api/web/accounts/requests/AccountRequest.java
+++ b/src/main/java/com/buddy/api/web/accounts/requests/AccountRequest.java
@@ -1,6 +1,7 @@
 package com.buddy.api.web.accounts.requests;
 
 import com.buddy.api.domains.account.dtos.AccountDto;
+import com.buddy.api.domains.valueobjects.EmailAddress;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
@@ -39,6 +40,6 @@ public record AccountRequest(
     Boolean termsOfUserConsent
 ) {
     public AccountDto toAccountDto() {
-        return new AccountDto(email, phoneNumber, password, termsOfUserConsent);
+        return new AccountDto(new EmailAddress(email), phoneNumber, password, termsOfUserConsent);
     }
 }

--- a/src/test/java/com/buddy/api/builders/account/AccountBuilder.java
+++ b/src/test/java/com/buddy/api/builders/account/AccountBuilder.java
@@ -1,6 +1,7 @@
 package com.buddy.api.builders.account;
 
 import static com.buddy.api.utils.RandomEmailUtils.generateValidEmail;
+import static com.buddy.api.utils.RandomEmailUtils.generateValidEmailAddress;
 import static com.buddy.api.utils.RandomStringUtils.generateRandomPassword;
 import static com.buddy.api.utils.RandomStringUtils.generateRandomPhoneNumber;
 
@@ -20,7 +21,7 @@ public class AccountBuilder {
     public static AccountEntity.AccountEntityBuilder validAccountEntity() {
         return AccountEntity
             .builder()
-            .email(generateValidEmail())
+            .email(generateValidEmailAddress())
             .phoneNumber(generateRandomPhoneNumber())
             .password(generateRandomPassword())
             .termsOfUserConsent(true)

--- a/src/test/java/com/buddy/api/builders/account/AccountBuilder.java
+++ b/src/test/java/com/buddy/api/builders/account/AccountBuilder.java
@@ -5,6 +5,7 @@ import static com.buddy.api.utils.RandomEmailUtils.generateValidEmailAddress;
 import static com.buddy.api.utils.RandomStringUtils.generateRandomPassword;
 import static com.buddy.api.utils.RandomStringUtils.generateRandomPhoneNumber;
 
+import com.buddy.api.domains.account.dtos.AccountDto;
 import com.buddy.api.domains.account.entities.AccountEntity;
 import com.buddy.api.web.accounts.requests.AccountRequest;
 
@@ -28,5 +29,14 @@ public class AccountBuilder {
             .isBlocked(false)
             .isVerified(false)
             .isDeleted(false);
+    }
+
+    public static AccountDto.AccountDtoBuilder validAccountDto() {
+        return AccountDto
+            .builder()
+            .email(generateValidEmailAddress())
+            .phoneNumber(generateRandomPhoneNumber())
+            .password(generateRandomPassword())
+            .termsOfUserConsent(true);
     }
 }

--- a/src/test/java/com/buddy/api/units/domains/services/impls/CreateAccountServiceTest.java
+++ b/src/test/java/com/buddy/api/units/domains/services/impls/CreateAccountServiceTest.java
@@ -3,6 +3,7 @@ package com.buddy.api.units.domains.services.impls;
 import static com.buddy.api.builders.account.AccountBuilder.validAccountDto;
 import static com.buddy.api.builders.account.AccountBuilder.validAccountEntity;
 import static com.buddy.api.utils.RandomStringUtils.generateRandomPassword;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.times;
@@ -17,6 +18,7 @@ import com.buddy.api.domains.account.services.impl.CreateAccountServiceImpl;
 import com.buddy.api.units.UnitTestAbstract;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.springframework.security.crypto.password.PasswordEncoder;
@@ -51,8 +53,15 @@ public class CreateAccountServiceTest extends UnitTestAbstract {
 
         createAccountService.create(accountDto);
 
+        var accountEntityCaptor = ArgumentCaptor.forClass(AccountEntity.class);
+
         verify(passwordEncoder, times(1)).encode(accountDto.password());
-        verify(accountRepository, times(1)).save(accountEntity);
+        verify(accountRepository, times(1))
+            .save(accountEntityCaptor.capture());
+
+        assertThat(accountEntity)
+            .usingRecursiveComparison()
+            .isEqualTo(accountEntityCaptor.getValue());
     }
 
     @Test

--- a/src/test/java/com/buddy/api/units/domains/services/impls/CreateAccountServiceTest.java
+++ b/src/test/java/com/buddy/api/units/domains/services/impls/CreateAccountServiceTest.java
@@ -1,6 +1,6 @@
 package com.buddy.api.units.domains.services.impls;
 
-import static com.buddy.api.utils.RandomEmailUtils.generateValidEmail;
+import static com.buddy.api.utils.RandomEmailUtils.generateValidEmailAddress;
 import static com.buddy.api.utils.RandomStringUtils.generateRandomPassword;
 import static com.buddy.api.utils.RandomStringUtils.generateRandomPhoneNumber;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -34,7 +34,7 @@ public class CreateAccountServiceTest extends UnitTestAbstract {
     @Test
     @DisplayName("Should create account")
     void should_create_account() {
-        final var email = generateValidEmail();
+        final var email = generateValidEmailAddress();
         final var phoneNumber = generateRandomPhoneNumber();
         final var password = generateRandomPassword();
         final var encryptedPassword = generateRandomPassword();
@@ -74,7 +74,7 @@ public class CreateAccountServiceTest extends UnitTestAbstract {
     @Test
     @DisplayName("Should not create account when email is already in database")
     void should_not_create_account_when_email_is_already_in_database() {
-        final var email = generateValidEmail();
+        final var email = generateValidEmailAddress();
         final var termsOfUserConsent = true;
 
         final AccountDto accountDto = new AccountDto(

--- a/src/test/java/com/buddy/api/units/domains/services/impls/CreateAccountServiceTest.java
+++ b/src/test/java/com/buddy/api/units/domains/services/impls/CreateAccountServiceTest.java
@@ -1,8 +1,8 @@
 package com.buddy.api.units.domains.services.impls;
 
-import static com.buddy.api.utils.RandomEmailUtils.generateValidEmailAddress;
+import static com.buddy.api.builders.account.AccountBuilder.validAccountDto;
+import static com.buddy.api.builders.account.AccountBuilder.validAccountEntity;
 import static com.buddy.api.utils.RandomStringUtils.generateRandomPassword;
-import static com.buddy.api.utils.RandomStringUtils.generateRandomPhoneNumber;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.times;
@@ -34,57 +34,33 @@ public class CreateAccountServiceTest extends UnitTestAbstract {
     @Test
     @DisplayName("Should create account")
     void should_create_account() {
-        final var email = generateValidEmailAddress();
-        final var phoneNumber = generateRandomPhoneNumber();
-        final var password = generateRandomPassword();
         final var encryptedPassword = generateRandomPassword();
-        final var termsOfUserConsent = true;
 
-        final AccountDto accountDto = new AccountDto(
-            email,
-            phoneNumber,
-            password,
-            termsOfUserConsent
-        );
+        final AccountDto accountDto = validAccountDto().build();
 
-        final AccountEntity accountEntity = new AccountEntity(
-            null,
-            email,
-            phoneNumber,
-            encryptedPassword,
-            termsOfUserConsent,
-            false,
-            false,
-            false,
-            null,
-            null,
-            null
-        );
+        final AccountEntity accountEntity = validAccountEntity()
+            .email(accountDto.email())
+            .password(encryptedPassword)
+            .phoneNumber(accountDto.phoneNumber())
+            .termsOfUserConsent(accountDto.termsOfUserConsent())
+            .build();
 
-        when(accountRepository.existsByEmail(email)).thenReturn(false);
-        when(passwordEncoder.encode(password)).thenReturn(encryptedPassword);
+        when(accountRepository.existsByEmail(accountDto.email())).thenReturn(false);
+        when(passwordEncoder.encode(accountDto.password())).thenReturn(encryptedPassword);
         when(accountRepository.save(accountEntity)).thenReturn(accountEntity);
 
         createAccountService.create(accountDto);
 
-        verify(passwordEncoder, times(1)).encode(password);
+        verify(passwordEncoder, times(1)).encode(accountDto.password());
         verify(accountRepository, times(1)).save(accountEntity);
     }
 
     @Test
     @DisplayName("Should not create account when email is already in database")
     void should_not_create_account_when_email_is_already_in_database() {
-        final var email = generateValidEmailAddress();
-        final var termsOfUserConsent = true;
+        final AccountDto accountDto = validAccountDto().build();
 
-        final AccountDto accountDto = new AccountDto(
-            email,
-            generateRandomPhoneNumber(),
-            generateRandomPassword(),
-            termsOfUserConsent
-        );
-
-        when(accountRepository.existsByEmail(email)).thenReturn(true);
+        when(accountRepository.existsByEmail(accountDto.email())).thenReturn(true);
 
         assertThatThrownBy(() -> createAccountService.create(accountDto))
             .isInstanceOf(EmailAlreadyRegisteredException.class)

--- a/src/test/java/com/buddy/api/units/domains/valueobjects/EmailAddressTest.java
+++ b/src/test/java/com/buddy/api/units/domains/valueobjects/EmailAddressTest.java
@@ -1,0 +1,51 @@
+package com.buddy.api.units.domains.valueobjects;
+
+import static com.buddy.api.utils.RandomEmailUtils.generateValidEmail;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.buddy.api.domains.valueobjects.EmailAddress;
+import com.buddy.api.units.UnitTestAbstract;
+import java.util.Locale;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+public class EmailAddressTest extends UnitTestAbstract {
+    @Test
+    @DisplayName("Should recognize equal email addresses")
+    void should_recognize_equal_email_adresses() {
+        var emailString = generateValidEmail();
+        var email = new EmailAddress(emailString);
+        var equivalentEmail = new EmailAddress(emailString);
+
+        assertThat(email).isEqualTo(equivalentEmail);
+    }
+
+    @Test
+    @DisplayName("Should distinguish distinct emails")
+    void should_distinguish_distinct_emails() {
+        var emailString = generateValidEmail();
+        var distinctEmailString = "a" + emailString;
+
+        var email = new EmailAddress(emailString);
+        var distinctEmail = new EmailAddress(distinctEmailString);
+
+        assertThat(email).isNotEqualTo(distinctEmail);
+    }
+
+    @Test
+    @DisplayName("Should consider email to be case insensitive")
+    void should_consider_email_to_be_case_insensitive() {
+        var lowerCaseEmailString = generateValidEmail().toLowerCase(Locale.ENGLISH);
+        var upperCaseEmailString = lowerCaseEmailString.toUpperCase(Locale.ENGLISH);
+
+        assertThat(new EmailAddress(lowerCaseEmailString))
+            .isEqualTo(new EmailAddress(upperCaseEmailString));
+    }
+
+    @Test
+    @DisplayName("Should resolve null emails to empty string emails")
+    void should_resolve_null_emails_to_empty_string() {
+        assertThat(new EmailAddress(null))
+            .isEqualTo(new EmailAddress(""));
+    }
+}

--- a/src/test/java/com/buddy/api/units/domains/valueobjects/EmailAddressTest.java
+++ b/src/test/java/com/buddy/api/units/domains/valueobjects/EmailAddressTest.java
@@ -46,11 +46,20 @@ public class EmailAddressTest extends UnitTestAbstract {
     }
 
     @Test
+    @DisplayName("Should ignore leading and trailing white spaces")
+    void should_ignore_leading_and_trailing_white_spaces() {
+        var email = generateValidEmail();
+
+        assertThat(new EmailAddress(email))
+            .isEqualTo(new EmailAddress(" " + email + " "));
+    }
+
+    @Test
     @DisplayName("Should not instantiate with null email value")
     void should_not_instantiate_with_null_email_value() {
         assertThatThrownBy(() -> new EmailAddress(null))
             .isInstanceOf(InvalidEmailAddressException.class)
-            .hasMessage("Email address value cannot be null or empty")
+            .hasMessage("Email address value cannot be null or blank")
             .extracting("fieldName")
             .isEqualTo("email");
     }
@@ -60,7 +69,17 @@ public class EmailAddressTest extends UnitTestAbstract {
     void should_not_instantiate_with_empty_email_value() {
         assertThatThrownBy(() -> new EmailAddress(""))
             .isInstanceOf(InvalidEmailAddressException.class)
-            .hasMessage("Email address value cannot be null or empty")
+            .hasMessage("Email address value cannot be null or blank")
+            .extracting("fieldName")
+            .isEqualTo("email");
+    }
+
+    @Test
+    @DisplayName("Should not instantiate with blank email value")
+    void should_not_instantiate_with_blank_email_value() {
+        assertThatThrownBy(() -> new EmailAddress(" "))
+            .isInstanceOf(InvalidEmailAddressException.class)
+            .hasMessage("Email address value cannot be null or blank")
             .extracting("fieldName")
             .isEqualTo("email");
     }

--- a/src/test/java/com/buddy/api/units/domains/valueobjects/EmailAddressTest.java
+++ b/src/test/java/com/buddy/api/units/domains/valueobjects/EmailAddressTest.java
@@ -11,6 +11,14 @@ import org.junit.jupiter.api.Test;
 
 public class EmailAddressTest extends UnitTestAbstract {
     @Test
+    @DisplayName("Should initialize empty email addresses")
+    void should_initialize_empty_email_adddress() {
+        var email = new EmailAddress();
+
+        assertThat(email.value()).isEqualTo("");
+    }
+
+    @Test
     @DisplayName("Should recognize equal email addresses")
     void should_recognize_equal_email_adresses() {
         var emailString = generateValidEmail();

--- a/src/test/java/com/buddy/api/units/domains/valueobjects/EmailAddressTest.java
+++ b/src/test/java/com/buddy/api/units/domains/valueobjects/EmailAddressTest.java
@@ -2,7 +2,9 @@ package com.buddy.api.units.domains.valueobjects;
 
 import static com.buddy.api.utils.RandomEmailUtils.generateValidEmail;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
+import com.buddy.api.commons.exceptions.InvalidEmailAddressException;
 import com.buddy.api.domains.valueobjects.EmailAddress;
 import com.buddy.api.units.UnitTestAbstract;
 import java.util.Locale;
@@ -10,13 +12,6 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
 public class EmailAddressTest extends UnitTestAbstract {
-    @Test
-    @DisplayName("Should initialize empty email addresses")
-    void should_initialize_empty_email_adddress() {
-        var email = new EmailAddress();
-
-        assertThat(email.value()).isEqualTo("");
-    }
 
     @Test
     @DisplayName("Should recognize equal email addresses")
@@ -51,9 +46,22 @@ public class EmailAddressTest extends UnitTestAbstract {
     }
 
     @Test
-    @DisplayName("Should resolve null emails to empty string emails")
-    void should_resolve_null_emails_to_empty_string() {
-        assertThat(new EmailAddress(null))
-            .isEqualTo(new EmailAddress(""));
+    @DisplayName("Should not instantiate with null email value")
+    void should_not_instantiate_with_null_email_value() {
+        assertThatThrownBy(() -> new EmailAddress(null))
+            .isInstanceOf(InvalidEmailAddressException.class)
+            .hasMessage("Email address value cannot be null or empty")
+            .extracting("fieldName")
+            .isEqualTo("email");
+    }
+
+    @Test
+    @DisplayName("Should not instantiate with empty email value")
+    void should_not_instantiate_with_empty_email_value() {
+        assertThatThrownBy(() -> new EmailAddress(""))
+            .isInstanceOf(InvalidEmailAddressException.class)
+            .hasMessage("Email address value cannot be null or empty")
+            .extracting("fieldName")
+            .isEqualTo("email");
     }
 }

--- a/src/test/java/com/buddy/api/utils/RandomEmailUtils.java
+++ b/src/test/java/com/buddy/api/utils/RandomEmailUtils.java
@@ -3,8 +3,14 @@ package com.buddy.api.utils;
 import static com.buddy.api.utils.RandomStringUtils.ALPHABET;
 import static com.buddy.api.utils.RandomStringUtils.generateRandomString;
 
+import com.buddy.api.domains.valueobjects.EmailAddress;
+
 public class RandomEmailUtils {
     public static String generateValidEmail() {
         return generateRandomString(10, ALPHABET) + "@example.com";
+    }
+
+    public static EmailAddress generateValidEmailAddress() {
+        return new EmailAddress(generateValidEmail());
     }
 }


### PR DESCRIPTION
## Descrição
A maior parte dos provedores de email consideram endereços de email como `case insensitive`. Até então, a `API` estava validando a unicidade dos emails cadastrados de forma `case sensitive`, então "test@email.com" era considerado diferente de 'TEST@EMAIL.COM".
Esta PR propõe o tratamento de emails como `case insensitive`.

### O que foi feito:
- Criado um novo teste de integração para o `CreateAccountController` que garante que a `API` não vai salvar dois emails equivalentes desconsiderando o case.
- Criado o ValueObject `EmailAddress` que abstrai o conceito de "email" para o sistema, considerando suas regras próprias.

### Por que foi feito:
- Essas mudanças são importantes para lidar corretamente com emails pela `API`. Garantir que email seja `case insensitive` para a `API` previne conflitos entre esquemas de autenticação e confirmação de emails.
- O encapsulamento do email como um `Value Object` torna claro que ele tem um status especial no domínio, com regras próprias, que devem ser observadas por todo o sistema.

## Tipos de mudanças
<!-- Marque com um "x" as opções que se aplicam. -->
- [ ] Correção de bug (mudança que corrige uma issue)
- [x] Nova funcionalidade (mudança que adiciona uma nova funcionalidade)
- [x] Refatoração (melhoria de código que não altera o comportamento do sistema)
- [ ] Alteração de documentação

## Checklist
<!-- Verifique se seu pull request segue as boas práticas listadas abaixo e marque as caixas. -->
- [x] O código segue o padrão de estilo e boas práticas do projeto.
- [x] Eu fiz uma revisão manual do código.
- [x] Testes foram escritos ou ajustados para cobrir as mudanças.
- [ ] A documentação foi atualizada, se necessário.

## Outras informações
<!-- Adicione qualquer outra informação relevante aqui. -->
