### PR TITLE
refactor: rename CreateAccountService

### DIFF
--- a/src/main/java/com/buddy/api/domains/account/services/CreateAccount.java
+++ b/src/main/java/com/buddy/api/domains/account/services/CreateAccount.java
@@ -2,6 +2,6 @@ package com.buddy.api.domains.account.services;
 
 import com.buddy.api.domains.account.dtos.AccountDto;
 
-public interface CreateAccountService {
+public interface CreateAccount {
     void create(AccountDto accountDto);
 }

--- a/src/main/java/com/buddy/api/domains/account/services/impl/CreateAccountImpl.java
+++ b/src/main/java/com/buddy/api/domains/account/services/impl/CreateAccountImpl.java
@@ -4,7 +4,7 @@ import com.buddy.api.commons.exceptions.EmailAlreadyRegisteredException;
 import com.buddy.api.domains.account.dtos.AccountDto;
 import com.buddy.api.domains.account.mappers.AccountMapper;
 import com.buddy.api.domains.account.repository.AccountRepository;
-import com.buddy.api.domains.account.services.CreateAccountService;
+import com.buddy.api.domains.account.services.CreateAccount;
 import com.buddy.api.domains.valueobjects.EmailAddress;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
@@ -13,7 +13,7 @@ import org.springframework.stereotype.Service;
 
 @Service
 @RequiredArgsConstructor
-public class CreateAccountServiceImpl implements CreateAccountService {
+public class CreateAccountImpl implements CreateAccount {
     private final AccountRepository accountRepository;
     private final PasswordEncoder passwordEncoder;
     private final AccountMapper accountMapper;

--- a/src/main/java/com/buddy/api/web/accounts/controllers/CreateAccountController.java
+++ b/src/main/java/com/buddy/api/web/accounts/controllers/CreateAccountController.java
@@ -1,6 +1,6 @@
 package com.buddy.api.web.accounts.controllers;
 
-import com.buddy.api.domains.account.services.CreateAccountService;
+import com.buddy.api.domains.account.services.CreateAccount;
 import com.buddy.api.web.accounts.requests.AccountRequest;
 import com.buddy.api.web.defaultresponses.CreatedSuccessResponse;
 import io.swagger.v3.oas.annotations.Operation;
@@ -19,7 +19,7 @@ import org.springframework.web.bind.annotation.RestController;
 @RequiredArgsConstructor
 @Tag(name = "Account", description = "Endpoint related to account registration")
 public class CreateAccountController {
-    private final CreateAccountService createAccountService;
+    private final CreateAccount createAccount;
 
     @PostMapping
     @ResponseStatus(HttpStatus.CREATED)
@@ -29,7 +29,7 @@ public class CreateAccountController {
     )
     public CreatedSuccessResponse registration(
         @Valid @RequestBody final AccountRequest accountRequest) {
-        createAccountService.create(accountRequest.toAccountDto());
+        createAccount.create(accountRequest.toAccountDto());
         return new CreatedSuccessResponse();
     }
 }

--- a/src/test/java/com/buddy/api/units/domains/services/impls/CreateAccountTest.java
+++ b/src/test/java/com/buddy/api/units/domains/services/impls/CreateAccountTest.java
@@ -15,7 +15,7 @@ import com.buddy.api.domains.account.dtos.AccountDto;
 import com.buddy.api.domains.account.entities.AccountEntity;
 import com.buddy.api.domains.account.mappers.AccountMapper;
 import com.buddy.api.domains.account.repository.AccountRepository;
-import com.buddy.api.domains.account.services.impl.CreateAccountServiceImpl;
+import com.buddy.api.domains.account.services.impl.CreateAccountImpl;
 import com.buddy.api.units.UnitTestAbstract;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -26,7 +26,7 @@ import org.mockito.Mock;
 import org.mockito.Spy;
 import org.springframework.security.crypto.password.PasswordEncoder;
 
-class CreateAccountServiceTest extends UnitTestAbstract {
+class CreateAccountTest extends UnitTestAbstract {
     @Mock
     private AccountRepository accountRepository;
 
@@ -37,7 +37,7 @@ class CreateAccountServiceTest extends UnitTestAbstract {
     private AccountMapper accountMapper = Mappers.getMapper(AccountMapper.class);
 
     @InjectMocks
-    CreateAccountServiceImpl createAccountService;
+    CreateAccountImpl createAccount;
 
     @Test
     @DisplayName("Should create account")
@@ -57,7 +57,7 @@ class CreateAccountServiceTest extends UnitTestAbstract {
         when(passwordEncoder.encode(accountDto.password())).thenReturn(encryptedPassword);
         when(accountRepository.save(accountEntity)).thenReturn(accountEntity);
 
-        createAccountService.create(accountDto);
+        createAccount.create(accountDto);
 
         var accountEntityCaptor = ArgumentCaptor.forClass(AccountEntity.class);
 
@@ -79,7 +79,7 @@ class CreateAccountServiceTest extends UnitTestAbstract {
 
         when(accountRepository.existsByEmail(accountDto.email())).thenReturn(true);
 
-        assertThatThrownBy(() -> createAccountService.create(accountDto))
+        assertThatThrownBy(() -> createAccount.create(accountDto))
             .isInstanceOf(EmailAlreadyRegisteredException.class)
             .hasMessage("Account email already registered")
             .extracting("fieldName")


### PR DESCRIPTION
## Descrição
<!-- Descreva brevemente o que foi feito nesta pull request e o motivo das mudanças. -->

### O que foi feito:
- Renomeei a interface `CreateAccountService` e sua implementação `CreateAccountServiceImpl` para `CreateAccount` e `CreateAccountImpl`.

### Por que foi feito:
- Para manter um padrão de nomenclatura entre este service e os demais existentes no sistema.

## Tipos de mudanças
<!-- Marque com um "x" as opções que se aplicam. -->
- [ ] Correção de bug (mudança que corrige uma issue)
- [ ] Nova funcionalidade (mudança que adiciona uma nova funcionalidade)
- [x] Refatoração (melhoria de código que não altera o comportamento do sistema)
- [ ] Alteração de documentação

## Checklist
<!-- Verifique se seu pull request segue as boas práticas listadas abaixo e marque as caixas. -->
- [x] O código segue o padrão de estilo e boas práticas do projeto.
- [ ] Eu fiz uma revisão manual do código.
- [ ] Testes foram escritos ou ajustados para cobrir as mudanças.
- [ ] A documentação foi atualizada, se necessário.

## Outras informações
<!-- Adicione qualquer outra informação relevante aqui. -->
