### PR TITLE
Proposta de adição do `ExecuteValidation` service

### DIFF
--- a/src/main/java/com/buddy/api/commons/exceptions/DomainValidationException.java
+++ b/src/main/java/com/buddy/api/commons/exceptions/DomainValidationException.java
@@ -1,0 +1,17 @@
+package com.buddy.api.commons.exceptions;
+
+import com.buddy.api.domains.validation.dtos.ValidationDetailsDto;
+import java.io.Serial;
+import java.util.List;
+
+public class DomainValidationException extends RuntimeException {
+
+    @Serial
+    private static final long serialVersionUID = 9206141270299873008L;
+    private final List<ValidationDetailsDto> errors;
+
+    public DomainValidationException(final List<ValidationDetailsDto> errors) {
+        super("validation failed");
+        this.errors = errors;
+    }
+}

--- a/src/main/java/com/buddy/api/domains/validation/dtos/ValidationDetailsDto.java
+++ b/src/main/java/com/buddy/api/domains/validation/dtos/ValidationDetailsDto.java
@@ -1,0 +1,4 @@
+package com.buddy.api.domains.validation.dtos;
+
+public record ValidationDetailsDto(String message, String fieldName) {
+}

--- a/src/main/java/com/buddy/api/domains/validation/service/ExecuteValidation.java
+++ b/src/main/java/com/buddy/api/domains/validation/service/ExecuteValidation.java
@@ -1,0 +1,12 @@
+package com.buddy.api.domains.validation.service;
+
+import com.buddy.api.domains.validation.dtos.ValidationDetailsDto;
+import java.util.List;
+import java.util.function.Supplier;
+
+public interface ExecuteValidation<T> {
+
+    ExecuteValidation<T> validate(Supplier<List<ValidationDetailsDto>> errors);
+
+    T andThen(Supplier<T> execution);
+}

--- a/src/main/java/com/buddy/api/domains/validation/service/impl/ExecuteValidationImpl.java
+++ b/src/main/java/com/buddy/api/domains/validation/service/impl/ExecuteValidationImpl.java
@@ -1,0 +1,27 @@
+package com.buddy.api.domains.validation.service.impl;
+
+import com.buddy.api.commons.exceptions.DomainValidationException;
+import com.buddy.api.domains.validation.dtos.ValidationDetailsDto;
+import com.buddy.api.domains.validation.service.ExecuteValidation;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.function.Supplier;
+
+public class ExecuteValidationImpl<T> implements ExecuteValidation<T> {
+    private final List<ValidationDetailsDto> errors = new ArrayList<>();
+
+    @Override
+    public ExecuteValidation<T> validate(final Supplier<List<ValidationDetailsDto>> errors) {
+        this.errors.addAll(errors.get());
+        return this;
+    }
+
+    @Override
+    public T andThen(final Supplier<T> execution) {
+        if (errors.isEmpty()) {
+            return execution.get();
+        }
+
+        throw new DomainValidationException(errors);
+    }
+}

--- a/src/test/java/com/buddy/api/units/domains/services/impls/ExecuteValidationTest.java
+++ b/src/test/java/com/buddy/api/units/domains/services/impls/ExecuteValidationTest.java
@@ -1,0 +1,81 @@
+package com.buddy.api.units.domains.services.impls;
+
+import static com.buddy.api.utils.RandomValidationDetailsUtils.generateRandomValidationDetailsDto;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.buddy.api.commons.exceptions.DomainValidationException;
+import com.buddy.api.domains.validation.dtos.ValidationDetailsDto;
+import com.buddy.api.domains.validation.service.impl.ExecuteValidationImpl;
+import com.buddy.api.units.UnitTestAbstract;
+import java.util.ArrayList;
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+public class ExecuteValidationTest extends UnitTestAbstract {
+    @Test
+    @DisplayName("Should execute normally with no validation")
+    void should_execute_normally_with_no_validations() {
+        final var executeValidation = new ExecuteValidationImpl<Boolean>();
+        final var executed = executeValidation.andThen(() -> true);
+
+        assertThat(executed).isTrue();
+    }
+
+    @Test
+    @DisplayName("Should throw validation exception when validation fails")
+    void should_throw_validation_exception_when_validation_fails() {
+        final var executeValidation = new ExecuteValidationImpl<Boolean>();
+
+        final var errors = List.of(
+            generateRandomValidationDetailsDto(),
+            generateRandomValidationDetailsDto()
+        );
+
+        assertThatThrownBy(() -> executeValidation
+            .validate(() -> errors)
+            .andThen(() -> true))
+            .isInstanceOf(DomainValidationException.class)
+            .hasMessage("validation failed")
+            .extracting("errors")
+            .isEqualTo(errors);
+    }
+
+    @Test
+    @DisplayName("Should execute normally when all validation succeeds")
+    void should_execute_normally_when_all_validations_succeeds() {
+        final var executeValidation = new ExecuteValidationImpl<Boolean>();
+        final var executed = executeValidation
+            .validate(List::of)
+            .andThen(() -> true);
+
+        assertThat(executed).isTrue();
+    }
+
+    @Test
+    @DisplayName("Should keep track of all failed validations")
+    void should_accumulate_validation_errors() {
+        final var executeValidation = new ExecuteValidationImpl<Boolean>();
+
+        final var errors = List.of(
+            generateRandomValidationDetailsDto(),
+            generateRandomValidationDetailsDto()
+        );
+
+        final var nextErrors = List.of(
+            generateRandomValidationDetailsDto()
+        );
+
+        final var allErrors = new ArrayList<ValidationDetailsDto>();
+        allErrors.addAll(errors);
+        allErrors.addAll(nextErrors);
+
+        assertThatThrownBy(() -> executeValidation
+            .validate(() -> errors)
+            .validate(() -> nextErrors)
+            .andThen(() -> true))
+            .extracting("errors")
+            .isEqualTo(allErrors);
+    }
+}

--- a/src/test/java/com/buddy/api/utils/RandomValidationDetailsUtils.java
+++ b/src/test/java/com/buddy/api/utils/RandomValidationDetailsUtils.java
@@ -1,0 +1,14 @@
+package com.buddy.api.utils;
+
+import static com.buddy.api.utils.RandomStringUtils.generateRandomString;
+
+import com.buddy.api.domains.validation.dtos.ValidationDetailsDto;
+
+public class RandomValidationDetailsUtils {
+    public static ValidationDetailsDto generateRandomValidationDetailsDto() {
+        return new ValidationDetailsDto(
+            generateRandomString(10),
+            generateRandomString(6)
+        );
+    }
+}


### PR DESCRIPTION
## Descrição
- Proposta de como um validador que acumula os erros de validação seria implementado;

### O que foi feito:
- Criado service `ExecuteValidation` que é responsável por controlar o ciclo de vida de `validação > ação` que deve ser seguido pelos demais services.
- Cria nova exceção que guarda os erros de validação. Essa classe posteriormente terá um `handler` no `Rest Controller Advice`.

### Por que foi feito:
- Como forma de avaliar possíveis implementações do proposto na issue #136  que não traga muitas complicasses e não traga o risco de ocultar erros.

## Tipos de mudanças
<!-- Marque com um "x" as opções que se aplicam. -->
- [ ] Correção de bug (mudança que corrige uma issue)
- [x] Nova funcionalidade (mudança que adiciona uma nova funcionalidade)
- [ ] Refatoração (melhoria de código que não altera o comportamento do sistema)
- [ ] Alteração de documentação

## Checklist
<!-- Verifique se seu pull request segue as boas práticas listadas abaixo e marque as caixas. -->
- [x] O código segue o padrão de estilo e boas práticas do projeto.
- [ ] Eu fiz uma revisão manual do código.
- [x] Testes foram escritos ou ajustados para cobrir as mudanças.
- [ ] A documentação foi atualizada, se necessário.

## Outras informações
Esse PR é só para fins de comparação de ideias e discussão. Conforme mencionei na issue #136, há dificuldades em adotar essa abordagem conforme se define em qual parte do sistema há a responsabilidade de "lançar as exceções" após as validações terminarem.

Neste PR coloquei a responsabilidade no próprio validador, mas isso força que os services dividam seu fluxo de trabalho de uma forma especifica: Primeiro realizem todas as validações através do `ExecuteValidation.validate()` e só no final chamem o `ExecuteValidation.andThen()`. Mas, da forma que foi feito, o `.andThen()` serve para um estágio posterior à validações, onde erros são reportados imediatamente. Portanto, em um cenário de comunicação entre diferentes services, deve-se ter cuidado ao chamar durante um `validate()` um service que também usa um `andthen()`, pois se um erro fosse lançado durante o `andThen` do segundo service, erros de validação anteriores não seriam reportados.

Uma melhoria então pode ser adicionar um tratamento no `andThen` para guardar esses erros de validação e os reportar junto com o erro acontecido no `andThen`.

Uma desvantagem comum à qualquer implementação desta abordagem de retorno de multiplos erros é a inabilidade de retornar códigos de status http precisos caso múltiplas validações falhem.