### PR TITLE
test: verify that ValidationCollection affects other requests

### DIFF
--- a/src/test/java/com/buddy/api/integrations/commons/validation/FakeValidationController.java
+++ b/src/test/java/com/buddy/api/integrations/commons/validation/FakeValidationController.java
@@ -1,0 +1,48 @@
+package com.buddy.api.integrations.commons.validation;
+
+import com.buddy.api.commons.exceptions.DomainException;
+import com.buddy.api.commons.validation.ValidationCollector;
+import com.buddy.api.web.advice.error.ErrorDetails;
+import java.time.LocalDateTime;
+import java.util.List;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/test/validationcollection")
+public class FakeValidationController {
+    private final ValidationCollector validationCollector;
+
+    public FakeValidationController(final ValidationCollector validationCollector) {
+        this.validationCollector = validationCollector;
+    }
+
+    @PostMapping("/invalidrequest")
+    @ResponseStatus(HttpStatus.OK)
+    public void validateWithError() {
+        this.validationCollector.validate(
+            () -> true,
+            new DomainException(
+                List.of(
+                    new ErrorDetails(
+                        "someField",
+                        "some message",
+                        HttpStatus.BAD_REQUEST,
+                        HttpStatus.BAD_REQUEST.value(),
+                        LocalDateTime.now()
+                    )
+                )
+            )
+        );
+    }
+
+    @GetMapping("/throw")
+    @ResponseStatus(HttpStatus.OK)
+    public void getErrors() {
+        validationCollector.throwIfErrors();
+    }
+}

--- a/src/test/java/com/buddy/api/integrations/commons/validation/ValidationCollectorTest.java
+++ b/src/test/java/com/buddy/api/integrations/commons/validation/ValidationCollectorTest.java
@@ -1,0 +1,27 @@
+package com.buddy.api.integrations.commons.validation;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.buddy.api.integrations.IntegrationTestAbstract;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+
+public class ValidationCollectorTest extends IntegrationTestAbstract {
+
+    private static final String API = "/test/validationcollection";
+
+    @Test
+    @DisplayName("should not conflict between requests")
+    void should_not_affect_other_requests() throws Exception {
+        mockMvc
+            .perform(post(API + "/invalidrequest"))
+            .andExpect(status().isOk());
+
+        mockMvc
+            .perform(get(API + "/throw"))
+            .andExpect(status().isOk());
+    }
+}


### PR DESCRIPTION
## Descrição
Um teste que verifica se o `ValidationCollection` pode afetar outros requests, uma vez que ele mantém um `state`.

### O que foi feito:
- endpoint `/test/validationcollection`: Endpoint de teste apenas para validar o funcionamento do `ValidationCollection` em um ambiente com multiplos requests;
- teste que verifica se o state do `ValidationCollection` vai ser compartilhado entre multiplos requests

### Por que foi feito:
- Se o state de um componente afeta multiplos `requests`, então é muito difícil garantir que em um ambiente com múltiplos requests simultâneos, um não irá afetar o outro. 

## Tipos de mudanças
<!-- Marque com um "x" as opções que se aplicam. -->
- [ ] Correção de bug (mudança que corrige uma issue)
- [ ] Nova funcionalidade (mudança que adiciona uma nova funcionalidade)
- [ ] Refatoração (melhoria de código que não altera o comportamento do sistema)
- [ ] Alteração de documentação

## Checklist
<!-- Verifique se seu pull request segue as boas práticas listadas abaixo e marque as caixas. -->
- [ ] O código segue o padrão de estilo e boas práticas do projeto.
- [ ] Eu fiz uma revisão manual do código.
- [x] Testes foram escritos ou ajustados para cobrir as mudanças.
- [ ] A documentação foi atualizada, se necessário.

## Outras informações
Embora é claro a partir do código do `ValidationCollection` que ele foi idealizado de tal forma que, após terminadas as validações, o método `throwIfErrors()` seria chamado, limpando os erros acumulados e lançando uma exception caso houvesse erros, o cenário que eu tentei emular é um em que dois usuários diferentes fariam requisições, e em um deles, haveria uma falha de validação, ao mesmo tempo em que o `throwIfErrors()` fosse chamado a partir da requisição do outro. Como o `state` é compartilhado entre os requests, isso faria um erro ser lançado para o segundo, mesmo que não foi ele quem causou as falhas na validação.

Infelizmente, é muito dificil testar esse tipo de cenário de forma confiável e determinista, assim, fiz os testes de tal forma que o `throwIfErrors` não fosse chamado imediatamente, para simular um segundo request em que o `state` estivesse sujo.

Devido a dificuldade de testar cenários envolvendo execução assíncrona entre múltiplos requests, penso que é mais seguro adotarmos uma abordagem mais principiológica, e determinar que:

1) De preferências, `Beans` não devem ter `state` (inclusive porque sendo uma `API REST`, ela deve ser `stateless`)
2) Se um `Bean` tem `state`, ele não deve ser um `singleton`

O Spring permite configurar o escopo de um `Bean` a partir da anotação `@Scope`. Podemos utilizá-la para controlar que o escopo de `Beans` com `state` seja somente o próprio `request`, assim, o state de um não afetará o de outro.

O estilo de teste que fiz nessa PR pode servir de base para verificarmos de forma mais confiável que o `state` de um bean não afeta outros requests, quando lidarmos com `beans` como este.