### PR TITLE
Add security context cleanup in tests

### DIFF
--- a/src/test/java/com/buddy/api/units/commons/configurations/secutiry/jwt/JwtAuthenticationFilterTest.java
+++ b/src/test/java/com/buddy/api/units/commons/configurations/secutiry/jwt/JwtAuthenticationFilterTest.java
@@ -14,6 +14,7 @@ import jakarta.servlet.FilterChain;
 import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.mockito.InjectMocks;
@@ -41,6 +42,11 @@ class JwtAuthenticationFilterTest extends UnitTestAbstract {
 
     @InjectMocks
     private JwtAuthenticationFilter jwtAuthenticationFilter;
+
+    @AfterEach
+    void clearSecurityContext() {
+        SecurityContextHolder.clearContext();
+    }
 
     @Test
     @DisplayName("Should authenticate user when valid JWT is present in Authorization header")


### PR DESCRIPTION
### 🤖 Resumo automático da IA

Aqui está o resumo para o Pull Request em formato markdown:

# Resumo do Pull Request

## Visão Geral
Esta PR adiciona um método `@AfterEach` para limpar o contexto de segurança após cada teste na classe `JwtAuthenticationFilterTest`.

## Propósito
O objetivo é garantir que o contexto de segurança seja limpo após cada teste executado, evitando possíveis vazamentos de estado entre testes e garantindo isolamento e consistência nos testes.

## Alterações
1. **JwtAuthenticationFilterTest.java**
   - Adicionado método `clearSecurityContext()` anotado com `@AfterEach`:
     ```java
     @AfterEach
     void clearSecurityContext() {
         SecurityContextHolder.clearContext();
     }
     ```
   - Este método será executado automaticamente após cada teste na classe para limpar o contexto de segurança

## Impacto
- **Positivo**: 
  - Melhora a confiabilidade dos testes ao garantir que cada teste comece com um contexto limpo
  - Evita possíveis efeitos colaterais entre testes
  - Mantém a consistência no ambiente de teste
- **Neutro**:
  - Não afeta o código de produção ou o desempenho da aplicação

## Testes
- A mudança não adiciona novos casos de teste, mas melhora a infraestrutura de teste existente
- Todos os testes existentes continuarão passando, agora com maior confiabilidade
- O método será executado automaticamente pelo JUnit após cada teste

## Notas
- Esta é uma boa prática padrão para testes que envolvem autenticação/segurança
- Não são necessárias dependências adicionais
- A mudança é simples e de baixo risco, focada apenas no ambiente de teste


---
## Summary
- clear `SecurityContextHolder` after each `JwtAuthenticationFilterTest` test

## Testing
- `./gradlew test --console=plain`
- `pre-commit run --files src/test/java/com/buddy/api/units/commons/configurations/secutiry/jwt/JwtAuthenticationFilterTest.java` *(fails: `Checkstyle` hook missing)*

------
https://chatgpt.com/codex/tasks/task_e_6845112e704883318e109597c3d15398