### PR TITLE
Rename authetication package

### DIFF
--- a/src/main/java/com/buddy/api/web/authentication/controllers/AuthController.java
+++ b/src/main/java/com/buddy/api/web/authentication/controllers/AuthController.java
@@ -1,11 +1,11 @@
-package com.buddy.api.web.authetication.controllers;
+package com.buddy.api.web.authentication.controllers;
 
 import com.buddy.api.commons.configurations.security.cookies.CookieManager;
 import com.buddy.api.domains.authentication.dtos.AuthDto;
 import com.buddy.api.domains.authentication.services.AuthService;
-import com.buddy.api.web.authetication.mappers.AuthenticationMapper;
-import com.buddy.api.web.authetication.requests.AuthRequest;
-import com.buddy.api.web.authetication.responses.AuthResponse;
+import com.buddy.api.web.authentication.mappers.AuthenticationMapper;
+import com.buddy.api.web.authentication.requests.AuthRequest;
+import com.buddy.api.web.authentication.responses.AuthResponse;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import jakarta.validation.Valid;

--- a/src/main/java/com/buddy/api/web/authentication/controllers/AuthControllerDoc.java
+++ b/src/main/java/com/buddy/api/web/authentication/controllers/AuthControllerDoc.java
@@ -1,8 +1,8 @@
-package com.buddy.api.web.authetication.controllers;
+package com.buddy.api.web.authentication.controllers;
 
 import com.buddy.api.web.advice.error.ErrorResponse;
-import com.buddy.api.web.authetication.requests.AuthRequest;
-import com.buddy.api.web.authetication.responses.AuthResponse;
+import com.buddy.api.web.authentication.requests.AuthRequest;
+import com.buddy.api.web.authentication.responses.AuthResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;

--- a/src/main/java/com/buddy/api/web/authentication/mappers/AuthenticationMapper.java
+++ b/src/main/java/com/buddy/api/web/authentication/mappers/AuthenticationMapper.java
@@ -1,8 +1,8 @@
-package com.buddy.api.web.authetication.mappers;
+package com.buddy.api.web.authentication.mappers;
 
 import com.buddy.api.domains.authentication.dtos.AuthDto;
-import com.buddy.api.web.authetication.requests.AuthRequest;
-import com.buddy.api.web.authetication.responses.AuthResponse;
+import com.buddy.api.web.authentication.requests.AuthRequest;
+import com.buddy.api.web.authentication.responses.AuthResponse;
 import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
 

--- a/src/main/java/com/buddy/api/web/authentication/requests/AuthRequest.java
+++ b/src/main/java/com/buddy/api/web/authentication/requests/AuthRequest.java
@@ -1,4 +1,4 @@
-package com.buddy.api.web.authetication.requests;
+package com.buddy.api.web.authentication.requests;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.Email;

--- a/src/main/java/com/buddy/api/web/authentication/responses/AuthResponse.java
+++ b/src/main/java/com/buddy/api/web/authentication/responses/AuthResponse.java
@@ -1,4 +1,4 @@
-package com.buddy.api.web.authetication.responses;
+package com.buddy.api.web.authentication.responses;
 
 import java.util.List;
 

--- a/src/main/java/com/buddy/api/web/authentication/responses/ProfileResponse.java
+++ b/src/main/java/com/buddy/api/web/authentication/responses/ProfileResponse.java
@@ -1,3 +1,3 @@
-package com.buddy.api.web.authetication.responses;
+package com.buddy.api.web.authentication.responses;
 
 public record ProfileResponse(String name, String description, String profileType) {}

--- a/src/test/java/com/buddy/api/integrations/web/authentication/controller/AuthControllerTest.java
+++ b/src/test/java/com/buddy/api/integrations/web/authentication/controller/AuthControllerTest.java
@@ -1,4 +1,4 @@
-package com.buddy.api.integrations.web.auth.controller;
+package com.buddy.api.integrations.web.authentication.controller;
 
 import static com.buddy.api.builders.account.AccountBuilder.validAccountEntity;
 import static com.buddy.api.customverifications.CustomErrorVerifications.expectBadRequestFrom;
@@ -20,7 +20,7 @@ import com.buddy.api.builders.profile.ProfileBuilder;
 import com.buddy.api.domains.account.entities.AccountEntity;
 import com.buddy.api.domains.profile.entities.ProfileEntity;
 import com.buddy.api.integrations.IntegrationTestAbstract;
-import com.buddy.api.web.authetication.requests.AuthRequest;
+import com.buddy.api.web.authentication.requests.AuthRequest;
 import jakarta.servlet.http.Cookie;
 import java.util.Objects;
 import org.apache.commons.lang3.RandomStringUtils;


### PR DESCRIPTION
### 🤖 Resumo automático da IA

# Análise do Pull Request - Correção de Nomenclatura

## Visão Geral
Este PR realiza a correção de nomenclatura em diversos arquivos, alterando o termo "authetication" para "authentication" em vários pacotes e imports. A mudança corrige um erro de digitação que estava presente na estrutura do projeto.

## Propósito
O principal objetivo desta alteração é:
- Corrigir a grafia incorreta da palavra "authentication" que estava escrita como "authetication"
- Manter a consistência na nomenclatura em todo o código-fonte
- Evitar possíveis confusões e problemas futuros de manutenção causados pela grafia inconsistente

## Alterações
Foram modificados 7 arquivos com renomeação de pacotes e imports:

1. **AuthController.java**
   - Correção do nome do pacote e imports relacionados
   ```java
   package com.buddy.api.web.authentication.controllers;
   // ...
   import com.buddy.api.web.authentication.mappers.AuthenticationMapper;
   import com.buddy.api.web.authentication.requests.AuthRequest;
   import com.buddy.api.web.authentication.responses.AuthResponse;
   ```

2. **AuthControllerDoc.java**
   - Mesma correção de nomenclatura
   ```java
   package com.buddy.api.web.authentication.controllers;
   // ...
   import com.buddy.api.web.authentication.requests.AuthRequest;
   import com.buddy.api.web.authentication.responses.AuthResponse;
   ```

3. **AuthenticationMapper.java**
   - Atualização do pacote e imports
   ```java
   package com.buddy.api.web.authentication.mappers;
   // ...
   import com.buddy.api.web.authentication.requests.AuthRequest;
   import com.buddy.api.web.authentication.responses.AuthResponse;
   ```

4. **AuthRequest.java**
   ```java
   package com.buddy.api.web.authentication.requests;
   ```

5. **AuthResponse.java**
   ```java
   package com.buddy.api.web.authentication.responses;
   ```

6. **ProfileResponse.java**
   ```java
   package com.buddy.api.web.authentication.responses;
   ```

7. **AuthControllerTest.java**
   - Correção no pacote e import
   ```java
   package com.buddy.api.integrations.web.authentication.controller;
   // ...
   import com.buddy.api.web.authentication.requests.AuthRequest;
   ```

## Impacto
- **Positivo**:
  - Melhora a legibilidade e consistência do código
  - Remove um potencial ponto de confusão para novos desenvolvedores
  - Facilita futuras manutenções
- **Neutro**:
  - Não há impacto na funcionalidade ou desempenho do sistema
  - Nenhuma alteração de comportamento foi introduzida

## Testes
- Os testes existentes continuam válidos e não foram modificados em sua lógica
- O teste de integração `AuthControllerTest` foi movido para o novo caminho correto
- Como esta é uma alteração apenas de nomenclatura, os testes existentes são suficientes para validar a mudança

## Notas
- É importante verificar se todas as referências à pasta/package "authetication" foram atualizadas
- Pode ser necessário:
  - Atualizar documentação ou comentários que possam conter a grafia incorreta
  - Verificar configurações de build ou deploy que possam referenciar o caminho antigo
- Esta mudança pode exigir um passo extra em ambientes de CI/CD para limpar caches ou artefatos antigos


---
### 🤖 Resumo automático da IA

# Análise do Pull Request - Correção de Nomenclatura de Autenticação

## Visão Geral
Esta PR consiste principalmente em renomear a estrutura de pacotes relacionada à autenticação, corrigindo a grafia incorreta de "authetication" para "authentication" em vários arquivos e pacotes.

## Propósito
A mudança tem como objetivo:
- Corrigir um erro de grafia no nome do pacote (`authetication` -> `authentication`)
- Manter a consistência na nomenclatura do projeto
- Evitar possíveis problemas futuros devido à grafia incorreta

## Alterações
Foram modificados 7 arquivos com renomeação de pacotes:

1. **AuthController.java**:
   - Pacote renomeado de `com.buddy.api.web.authetication.controllers` para `com.buddy.api.web.authentication.controllers`
   - Atualização dos imports relacionados

   ```java
   package com.buddy.api.web.authentication.controllers;
   ```

2. **AuthControllerDoc.java**:
   - Mesma correção de pacote e imports

3. **AuthenticationMapper.java**:
   - Pacote e imports atualizados
   ```java
   package com.buddy.api.web.authentication.mappers;
   ```

4. **AuthRequest.java**:
   - Correção do pacote
   ```java
   package com.buddy.api.web.authentication.requests;
   ```

5. **AuthResponse.java** e **ProfileResponse.java**:
   - Correção nos pacotes dos arquivos de response

6. **AuthControllerTest.java**:
   - Pacote renomeado de `com.buddy.api.integrations.web.auth.controller` para `com.buddy.api.integrations.web.authentication.controller`
   - Import do AuthRequest atualizado

   ```java
   package com.buddy.api.integrations.web.authentication.controller;
   ```

## Impacto
- **Código**: Melhoria na consistência e corretude da nomenclatura
- **Funcionalidade**: Nenhum impacto na funcionalidade existente
- **Manutenção**: Facilita a localização de classes relacionadas à autenticação
- **Quebras**: Pode requerer atualização em outros arquivos que faziam referência aos pacotes antigos

## Testes
- Os testes existentes foram mantidos e apenas atualizados para a nova nomenclatura
- O arquivo de teste `AuthControllerTest.java` foi renomeado e continua funcionando normalmente

## Notas
1. É recomendado verificar se não há outras referências aos pacotes antigos em outros lugares do código
2. O Git detectou alta similaridade (89-99%) entre os arquivos antigos e novos, indicando que apenas as referências de pacote foram alteradas
3. A mudança de `web.auth` para `web.authentication` no pacote de testes também melhora a consistência com a estrutura principal


---
## Summary
- rename `web/authetication` package to `web/authentication`
- update imports and tests accordingly

## Testing
- `./gradlew test --no-daemon`

------
https://chatgpt.com/codex/tasks/task_e_6845112a236c83319da2f72daacd6f6a