### PR TITLE
feat: add endpoint active terms of use

### DIFF
--- a/src/main/java/com/buddy/api/commons/exceptions/PetSearchException.java
+++ b/src/main/java/com/buddy/api/commons/exceptions/PetSearchException.java
@@ -1,11 +1,10 @@
 package com.buddy.api.commons.exceptions;
 
 import java.io.Serial;
-import java.io.Serializable;
 import lombok.Getter;
 
 @Getter
-public class PetSearchException extends RuntimeException implements Serializable {
+public class PetSearchException extends RuntimeException {
 
     @Serial
     private static final long serialVersionUID = 1704349073637945329L;

--- a/src/main/java/com/buddy/api/domains/terms/repositories/TermsVersionRepository.java
+++ b/src/main/java/com/buddy/api/domains/terms/repositories/TermsVersionRepository.java
@@ -14,10 +14,10 @@ public interface TermsVersionRepository extends JpaRepository<TermsVersionEntity
     Optional<TermsVersionEntity> findByVersionTag(String versionTag);
 
     @Modifying(clearAutomatically = true, flushAutomatically = true)
-    @Query("UPDATE TermsVersionEntity t SET t.isActive = false WHERE t.isActive = true")
-    int deactivateAllActive();
-
-    @Modifying(clearAutomatically = true, flushAutomatically = true)
-    @Query("UPDATE TermsVersionEntity t SET t.isActive = true WHERE t.termsVersionId = :id")
-    int activateById(@Param("id") UUID id);
+    @Query("""
+            UPDATE TermsVersionEntity t
+               SET t.isActive = CASE WHEN t.termsVersionId = :id THEN true ELSE false END
+             WHERE t.isActive = true OR t.termsVersionId = :id
+        """)
+    int switchActiveById(@Param("id") UUID id);
 }

--- a/src/main/java/com/buddy/api/domains/terms/repositories/TermsVersionRepository.java
+++ b/src/main/java/com/buddy/api/domains/terms/repositories/TermsVersionRepository.java
@@ -6,6 +6,7 @@ import java.util.UUID;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface TermsVersionRepository extends JpaRepository<TermsVersionEntity, UUID> {
     Optional<TermsVersionEntity> findFirstByIsActiveTrueOrderByPublicationDateDesc();
@@ -15,4 +16,8 @@ public interface TermsVersionRepository extends JpaRepository<TermsVersionEntity
     @Modifying(clearAutomatically = true, flushAutomatically = true)
     @Query("UPDATE TermsVersionEntity t SET t.isActive = false WHERE t.isActive = true")
     int deactivateAllActive();
+
+    @Modifying(clearAutomatically = true, flushAutomatically = true)
+    @Query("UPDATE TermsVersionEntity t SET t.isActive = true WHERE t.termsVersionId = :id")
+    int activateById(@Param("id") UUID id);
 }

--- a/src/main/java/com/buddy/api/domains/terms/services/ActivateTermsVersion.java
+++ b/src/main/java/com/buddy/api/domains/terms/services/ActivateTermsVersion.java
@@ -1,0 +1,7 @@
+package com.buddy.api.domains.terms.services;
+
+import java.util.UUID;
+
+public interface ActivateTermsVersion {
+    void activate(UUID termsVersionId);
+}

--- a/src/main/java/com/buddy/api/domains/terms/services/FindTermsVersion.java
+++ b/src/main/java/com/buddy/api/domains/terms/services/FindTermsVersion.java
@@ -2,9 +2,12 @@ package com.buddy.api.domains.terms.services;
 
 import com.buddy.api.domains.terms.dtos.TermsVersionDto;
 import java.util.Optional;
+import java.util.UUID;
 
 public interface FindTermsVersion {
     TermsVersionDto findActive();
+
+    TermsVersionDto findById(UUID termsVersionId);
 
     Optional<TermsVersionDto> findByTag(String versionTag);
 }

--- a/src/main/java/com/buddy/api/domains/terms/services/impl/ActivateTermsVersionImpl.java
+++ b/src/main/java/com/buddy/api/domains/terms/services/impl/ActivateTermsVersionImpl.java
@@ -31,8 +31,7 @@ public class ActivateTermsVersionImpl implements ActivateTermsVersion {
             return;
         }
 
-        termsVersionRepository.deactivateAllActive();
-        termsVersionRepository.activateById(termsVersionId);
+        termsVersionRepository.switchActiveById(termsVersionId);
 
         log.info("Terms version activated successfully with id: {}", termsVersionId);
     }

--- a/src/main/java/com/buddy/api/domains/terms/services/impl/ActivateTermsVersionImpl.java
+++ b/src/main/java/com/buddy/api/domains/terms/services/impl/ActivateTermsVersionImpl.java
@@ -1,0 +1,39 @@
+package com.buddy.api.domains.terms.services.impl;
+
+import com.buddy.api.domains.terms.repositories.TermsVersionRepository;
+import com.buddy.api.domains.terms.services.ActivateTermsVersion;
+import com.buddy.api.domains.terms.services.FindTermsVersion;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.cache.annotation.CacheEvict;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class ActivateTermsVersionImpl implements ActivateTermsVersion {
+
+    private final TermsVersionRepository termsVersionRepository;
+    private final FindTermsVersion findTermsVersion;
+
+    @Override
+    @Transactional
+    @CacheEvict(value = "terms", key = "'active'")
+    public void activate(final UUID termsVersionId) {
+        log.info("Activating terms version with id: {}", termsVersionId);
+
+        final var termsVersion = findTermsVersion.findById(termsVersionId);
+
+        if (termsVersion.isActive()) {
+            log.info("Terms version is already active, returning current state");
+            return;
+        }
+
+        termsVersionRepository.deactivateAllActive();
+        termsVersionRepository.activateById(termsVersionId);
+
+        log.info("Terms version activated successfully with id: {}", termsVersionId);
+    }
+}

--- a/src/main/java/com/buddy/api/domains/terms/services/impl/CreateTermsVersionImpl.java
+++ b/src/main/java/com/buddy/api/domains/terms/services/impl/CreateTermsVersionImpl.java
@@ -6,11 +6,11 @@ import com.buddy.api.domains.terms.dtos.CreateTermsVersionDto;
 import com.buddy.api.domains.terms.dtos.TermsVersionDto;
 import com.buddy.api.domains.terms.mappers.TermsMapper;
 import com.buddy.api.domains.terms.repositories.TermsVersionRepository;
+import com.buddy.api.domains.terms.services.ActivateTermsVersion;
 import com.buddy.api.domains.terms.services.CreateTermsVersion;
 import com.buddy.api.domains.terms.services.FindTermsVersion;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.cache.annotation.CacheEvict;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -22,39 +22,36 @@ public class CreateTermsVersionImpl implements CreateTermsVersion {
     private final TermsVersionRepository termsVersionRepository;
     private final FindAccount findAccount;
     private final FindTermsVersion findTermsVersion;
+    private final ActivateTermsVersion activateTermsVersion;
     private final TermsMapper termsMapper;
 
     @Override
     @Transactional
-    @CacheEvict(value = "terms", key = "'active'", condition = "#dto.isActive() == true")
     public TermsVersionDto create(final CreateTermsVersionDto dto) {
         log.info("Creating new terms version with tag: {}", dto.versionTag());
 
         validateVersionTagNotExists(dto.versionTag());
 
         final var publishedByDto = findAccount.findByEmail(dto.publishedByAccountEmail());
-        final var isActive = Boolean.TRUE.equals(dto.isActive());
+        final var entityToSave = termsMapper.toTermsVersionEntity(dto, publishedByDto, false);
 
-        if (isActive) {
-            log.info("Deactivating all currently active terms versions before DB change");
-            termsVersionRepository.deactivateAllActive();
-            log.info("Deactivated all currently active terms versions after DB change");
+        log.info("Saving new terms version to database as inactive draft");
+        final var savedEntity = termsVersionRepository.save(entityToSave);
+
+        if (Boolean.TRUE.equals(dto.isActive())) {
+            log.info("Delegating to ActivateTermsVersion to set as active atomically");
+            activateTermsVersion.activate(savedEntity.getTermsVersionId());
+            savedEntity.setIsActive(true);
         }
 
-        final var entityToSave = termsMapper.toTermsVersionEntity(dto, publishedByDto, isActive);
-
-        log.info("Saving new terms version to database");
-        final var savedEntity = termsVersionRepository.save(entityToSave);
         log.info("Terms version created successfully with id: {}", savedEntity.getTermsVersionId());
-
         return termsMapper.toTermsVersionDto(savedEntity);
     }
 
     private void validateVersionTagNotExists(final String versionTag) {
-        findTermsVersion.findByTag(versionTag)
-            .ifPresent(existing -> {
-                log.debug("Version tag already exists: {}", versionTag);
-                throw new VersionTagAlreadyExistsException(versionTag);
-            });
+        if (findTermsVersion.findByTag(versionTag).isPresent()) {
+            log.warn("Version tag already exists: {}", versionTag);
+            throw new VersionTagAlreadyExistsException(versionTag);
+        }
     }
 }

--- a/src/main/java/com/buddy/api/domains/terms/services/impl/FindTermsVersionImpl.java
+++ b/src/main/java/com/buddy/api/domains/terms/services/impl/FindTermsVersionImpl.java
@@ -6,6 +6,7 @@ import com.buddy.api.domains.terms.mappers.TermsMapper;
 import com.buddy.api.domains.terms.repositories.TermsVersionRepository;
 import com.buddy.api.domains.terms.services.FindTermsVersion;
 import java.util.Optional;
+import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.cache.annotation.Cacheable;
@@ -27,6 +28,16 @@ public class FindTermsVersionImpl implements FindTermsVersion {
         return termsMapper.toTermsVersionDto(
             termsVersionRepository.findFirstByIsActiveTrueOrderByPublicationDateDesc()
                 .orElseThrow(() -> new NotFoundException("terms", "No active terms found")));
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public TermsVersionDto findById(final UUID termsVersionId) {
+        final var entity = termsVersionRepository.findById(termsVersionId)
+            .orElseThrow(() -> new NotFoundException(
+                "termsVersionId",
+                "Terms version not found with id: " + termsVersionId));
+        return termsMapper.toTermsVersionDto(entity);
     }
 
     @Override

--- a/src/main/java/com/buddy/api/web/terms/controllers/ActivateTermsVersionController.java
+++ b/src/main/java/com/buddy/api/web/terms/controllers/ActivateTermsVersionController.java
@@ -1,0 +1,27 @@
+package com.buddy.api.web.terms.controllers;
+
+import com.buddy.api.domains.terms.services.ActivateTermsVersion;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/v1/terms")
+@RequiredArgsConstructor
+public class ActivateTermsVersionController implements ActivateTermsVersionControllerDoc {
+    private final ActivateTermsVersion activateTermsVersion;
+
+    @Override
+    @PatchMapping("/{termsVersionId}/activate")
+    @ResponseStatus(HttpStatus.NO_CONTENT)
+    @PreAuthorize("hasRole('ADMIN')")
+    public void activateVersion(@PathVariable final UUID termsVersionId) {
+        activateTermsVersion.activate(termsVersionId);
+    }
+}

--- a/src/main/java/com/buddy/api/web/terms/controllers/ActivateTermsVersionControllerDoc.java
+++ b/src/main/java/com/buddy/api/web/terms/controllers/ActivateTermsVersionControllerDoc.java
@@ -1,0 +1,38 @@
+package com.buddy.api.web.terms.controllers;
+
+import com.buddy.api.web.terms.responses.TermsVersionResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import java.util.UUID;
+
+@Tag(name = "Terms Admin", description = "Administrative operations for Terms of Use management")
+public interface ActivateTermsVersionControllerDoc {
+
+    @Operation(summary = "Activate a Terms of Use version",
+        description = "Activates the specified Terms of Use version, "
+            + "deactivating all other versions. "
+            + "Only one version can be active at a time. "
+            +
+            "Only ADMIN users can perform this operation.",
+        security = @SecurityRequirement(name = "bearerAuth"))
+    @ApiResponses(value = {
+        @ApiResponse(responseCode = "200",
+            description = "Terms version activated successfully",
+            content = @Content(mediaType = "application/json",
+                schema = @Schema(implementation = TermsVersionResponse.class))),
+        @ApiResponse(responseCode = "401",
+            description = "Unauthorized - missing or invalid JWT token", content = @Content),
+        @ApiResponse(responseCode = "403",
+            description = "Forbidden - user does not have ADMIN role", content = @Content),
+        @ApiResponse(responseCode = "404",
+            description = "Not Found - terms version does not exist", content = @Content)})
+    void activateVersion(
+        @Parameter(description = "UUID of the terms version to activate", required = true)
+        UUID termsVersionId);
+}

--- a/src/main/java/com/buddy/api/web/terms/controllers/ActivateTermsVersionControllerDoc.java
+++ b/src/main/java/com/buddy/api/web/terms/controllers/ActivateTermsVersionControllerDoc.java
@@ -1,10 +1,8 @@
 package com.buddy.api.web.terms.controllers;
 
-import com.buddy.api.web.terms.responses.TermsVersionResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.media.Content;
-import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
@@ -22,10 +20,9 @@ public interface ActivateTermsVersionControllerDoc {
             "Only ADMIN users can perform this operation.",
         security = @SecurityRequirement(name = "bearerAuth"))
     @ApiResponses(value = {
-        @ApiResponse(responseCode = "200",
+        @ApiResponse(responseCode = "204",
             description = "Terms version activated successfully",
-            content = @Content(mediaType = "application/json",
-                schema = @Schema(implementation = TermsVersionResponse.class))),
+            content = @Content),
         @ApiResponse(responseCode = "401",
             description = "Unauthorized - missing or invalid JWT token", content = @Content),
         @ApiResponse(responseCode = "403",

--- a/src/test/java/com/buddy/api/components/TermsComponent.java
+++ b/src/test/java/com/buddy/api/components/TermsComponent.java
@@ -4,6 +4,7 @@ import com.buddy.api.builders.terms.TermsBuilder;
 import com.buddy.api.domains.account.entities.AccountEntity;
 import com.buddy.api.domains.terms.entities.TermsVersionEntity;
 import com.buddy.api.domains.terms.repositories.TermsVersionRepository;
+import org.apache.commons.lang3.RandomStringUtils;
 import org.springframework.stereotype.Component;
 
 @Component
@@ -19,17 +20,18 @@ public class TermsComponent {
         return termsVersionRepository.save(
             TermsBuilder.validTermsVersionEntity()
                 .isActive(true)
-                .versionTag("v1.0.0")
+                .versionTag(RandomStringUtils.secure().nextAlphanumeric(10))
                 .publishedBy(account)
                 .build()
         );
     }
 
-    public TermsVersionEntity createInactiveTerm() {
+    public TermsVersionEntity createInactiveTerm(final AccountEntity account) {
         return termsVersionRepository.save(
             TermsBuilder.validTermsVersionEntity()
                 .isActive(false)
-                .versionTag("v0.9.beta")
+                .versionTag(RandomStringUtils.secure().nextAlphanumeric(10))
+                .publishedBy(account)
                 .build()
         );
     }

--- a/src/test/java/com/buddy/api/integrations/web/terms/controller/ActivateTermsVersionControllerTest.java
+++ b/src/test/java/com/buddy/api/integrations/web/terms/controller/ActivateTermsVersionControllerTest.java
@@ -1,0 +1,124 @@
+package com.buddy.api.integrations.web.terms.controller;
+
+import static com.buddy.api.customverifications.CustomErrorVerifications.expectNotFoundFrom;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.buddy.api.integrations.IntegrationTestAbstract;
+import java.util.UUID;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+class ActivateTermsVersionControllerTest extends IntegrationTestAbstract {
+
+    private static final String ACTIVATE_URL_TEMPLATE = TERMS_BASE_URL + "/%s/activate";
+
+    @Nested
+    @DisplayName("PATCH /v1/terms/{id}/activate - Success Scenarios")
+    class SuccessScenarios {
+
+        @Test
+        @DisplayName("Should activate an inactive terms version and return 204 without body")
+        void should_activate_inactive_terms_version() throws Exception {
+            final var adminUser = accountComponent.createAndAuthenticateAdmin();
+            final var inactiveTerms = termsComponent.createInactiveTerm(adminUser.account());
+
+            final var activateUrl = String.format(ACTIVATE_URL_TEMPLATE,
+                inactiveTerms.getTermsVersionId());
+
+            mockMvc.perform(patch(activateUrl)
+                    .header(AUTHORIZATION, BEARER + adminUser.jwt()))
+                .andExpect(status().isNoContent());
+
+            final var updatedEntity = termsVersionRepository
+                .findById(inactiveTerms.getTermsVersionId());
+            assertThat(updatedEntity).isPresent();
+            assertThat(updatedEntity.get().getIsActive()).isTrue();
+        }
+
+        @Test
+        @DisplayName("Should deactivate previously active version when activating a new one")
+        void should_deactivate_previous_active_version() throws Exception {
+            final var adminUser = accountComponent.createAndAuthenticateAdmin();
+            final var activeTerms = termsComponent.createActiveTerm(adminUser.account());
+            final var inactiveTerms = termsComponent.createInactiveTerm(adminUser.account());
+
+            final var activateUrl = String.format(ACTIVATE_URL_TEMPLATE,
+                inactiveTerms.getTermsVersionId());
+
+            mockMvc.perform(patch(activateUrl)
+                    .header(AUTHORIZATION, BEARER + adminUser.jwt()))
+                .andExpect(status().isNoContent());
+
+            final var previouslyActive = termsVersionRepository
+                .findById(activeTerms.getTermsVersionId());
+            assertThat(previouslyActive).isPresent();
+            assertThat(previouslyActive.get().getIsActive()).isFalse();
+
+            final var newlyActive = termsVersionRepository
+                .findById(inactiveTerms.getTermsVersionId());
+            assertThat(newlyActive).isPresent();
+            assertThat(newlyActive.get().getIsActive()).isTrue();
+        }
+
+        @Test
+        @DisplayName("Should return 204 no content when activating an already active version")
+        void should_return_204_when_already_active() throws Exception {
+            final var adminUser = accountComponent.createAndAuthenticateAdmin();
+            final var activeTerms = termsComponent.createActiveTerm(adminUser.account());
+
+            final var activateUrl = String.format(ACTIVATE_URL_TEMPLATE,
+                activeTerms.getTermsVersionId());
+
+            mockMvc.perform(patch(activateUrl)
+                    .header(AUTHORIZATION, BEARER + adminUser.jwt()))
+                .andExpect(status().isNoContent());
+        }
+    }
+
+    @Nested
+    @DisplayName("PATCH /v1/terms/{id}/activate - Security & Authorization")
+    class SecurityScenarios {
+
+        @Test
+        @DisplayName("Should return 403 Forbidden when no token is provided")
+        void should_return_403_when_no_token() throws Exception {
+            final var activateUrl = String.format(ACTIVATE_URL_TEMPLATE, UUID.randomUUID());
+
+            mockMvc.perform(patch(activateUrl))
+                .andExpect(status().isForbidden());
+        }
+
+        @Test
+        @DisplayName("Should return 403 Forbidden when user is not ADMIN")
+        void should_return_403_when_not_admin() throws Exception {
+            final var regularUser = accountComponent.createAndAuthenticateUser();
+            final var activateUrl = String.format(ACTIVATE_URL_TEMPLATE, UUID.randomUUID());
+
+            mockMvc.perform(patch(activateUrl)
+                    .header(AUTHORIZATION, BEARER + regularUser.jwt()))
+                .andExpect(status().isForbidden());
+        }
+    }
+
+    @Nested
+    @DisplayName("PATCH /v1/terms/{id}/activate - Error Scenarios")
+    class ErrorScenarios {
+
+        @Test
+        @DisplayName("Should return 404 Not Found when terms version does not exist")
+        void should_return_404_when_id_not_found() throws Exception {
+            final var adminUser = accountComponent.createAndAuthenticateAdmin();
+            final var nonExistentId = UUID.randomUUID();
+            final var activateUrl = String.format(ACTIVATE_URL_TEMPLATE, nonExistentId);
+
+            expectNotFoundFrom(mockMvc.perform(patch(activateUrl)
+                .header(AUTHORIZATION, BEARER + adminUser.jwt())))
+                .withTotalErrors(1)
+                .forField("termsVersionId",
+                    "Terms version not found with id: " + nonExistentId);
+        }
+    }
+}

--- a/src/test/java/com/buddy/api/units/domains/services/impl/ActivateTermsVersionImplTest.java
+++ b/src/test/java/com/buddy/api/units/domains/services/impl/ActivateTermsVersionImplTest.java
@@ -1,0 +1,115 @@
+package com.buddy.api.units.domains.services.impl;
+
+import static com.buddy.api.builders.terms.TermsBuilder.validTermsVersionDto;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.buddy.api.commons.exceptions.NotFoundException;
+import com.buddy.api.domains.terms.dtos.TermsVersionDto;
+import com.buddy.api.domains.terms.repositories.TermsVersionRepository;
+import com.buddy.api.domains.terms.services.FindTermsVersion;
+import com.buddy.api.domains.terms.services.impl.ActivateTermsVersionImpl;
+import com.buddy.api.units.UnitTestAbstract;
+import java.util.UUID;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+
+class ActivateTermsVersionImplTest extends UnitTestAbstract {
+
+    @Mock
+    private TermsVersionRepository termsVersionRepository;
+
+    @Mock
+    private FindTermsVersion findTermsVersion;
+
+    @InjectMocks
+    private ActivateTermsVersionImpl activateTermsVersion;
+
+    @Nested
+    @DisplayName("Success Scenarios")
+    class SuccessScenarios {
+
+        @Test
+        @DisplayName("Should activate an inactive terms version and deactivate all others")
+        void should_activate_inactive_version() {
+            final UUID termsVersionId = UUID.randomUUID();
+
+            final TermsVersionDto inactiveDto = validTermsVersionDto()
+                .termsVersionId(termsVersionId)
+                .isActive(false)
+                .build();
+
+            final TermsVersionDto activatedDto = validTermsVersionDto()
+                .termsVersionId(termsVersionId)
+                .versionTag(inactiveDto.versionTag())
+                .content(inactiveDto.content())
+                .publicationDate(inactiveDto.publicationDate())
+                .isActive(true)
+                .build();
+
+            when(findTermsVersion.findById(termsVersionId))
+                .thenReturn(inactiveDto)
+                .thenReturn(activatedDto);
+            when(termsVersionRepository.deactivateAllActive()).thenReturn(1);
+            when(termsVersionRepository.activateById(termsVersionId)).thenReturn(1);
+
+            activateTermsVersion.activate(termsVersionId);
+
+            verify(findTermsVersion, times(1)).findById(termsVersionId);
+            verify(termsVersionRepository, times(1)).deactivateAllActive();
+            verify(termsVersionRepository, times(1)).activateById(termsVersionId);
+        }
+
+        @Test
+        @DisplayName("Should return current state when version is already active (idempotent)")
+        void should_return_current_state_when_already_active() {
+            final UUID termsVersionId = UUID.randomUUID();
+
+            final TermsVersionDto activeDto = validTermsVersionDto()
+                .termsVersionId(termsVersionId)
+                .isActive(true)
+                .build();
+
+            when(findTermsVersion.findById(termsVersionId))
+                .thenReturn(activeDto);
+
+            activateTermsVersion.activate(termsVersionId);
+
+            verify(findTermsVersion, times(1)).findById(termsVersionId);
+            verify(termsVersionRepository, never()).deactivateAllActive();
+            verify(termsVersionRepository, never()).activateById(termsVersionId);
+        }
+    }
+
+    @Nested
+    @DisplayName("Error Scenarios")
+    class ErrorScenarios {
+
+        @Test
+        @DisplayName("Should throw NotFoundException when terms version does not exist")
+        void should_throw_not_found_when_id_does_not_exist() {
+            final UUID nonExistentId = UUID.randomUUID();
+
+            when(findTermsVersion.findById(nonExistentId))
+                .thenThrow(new NotFoundException(
+                    "termsVersionId",
+                    "Terms version not found with id: " + nonExistentId));
+
+            assertThatThrownBy(() -> activateTermsVersion.activate(nonExistentId))
+                .isInstanceOf(NotFoundException.class)
+                .hasMessageContaining(
+                    "Terms version not found with id: " + nonExistentId
+                );
+
+            verify(findTermsVersion, times(1)).findById(nonExistentId);
+            verify(termsVersionRepository, never()).deactivateAllActive();
+            verify(termsVersionRepository, never()).activateById(nonExistentId);
+        }
+    }
+}

--- a/src/test/java/com/buddy/api/units/domains/services/impl/ActivateTermsVersionImplTest.java
+++ b/src/test/java/com/buddy/api/units/domains/services/impl/ActivateTermsVersionImplTest.java
@@ -56,14 +56,12 @@ class ActivateTermsVersionImplTest extends UnitTestAbstract {
             when(findTermsVersion.findById(termsVersionId))
                 .thenReturn(inactiveDto)
                 .thenReturn(activatedDto);
-            when(termsVersionRepository.deactivateAllActive()).thenReturn(1);
-            when(termsVersionRepository.activateById(termsVersionId)).thenReturn(1);
+            when(termsVersionRepository.switchActiveById(termsVersionId)).thenReturn(1);
 
             activateTermsVersion.activate(termsVersionId);
 
             verify(findTermsVersion, times(1)).findById(termsVersionId);
-            verify(termsVersionRepository, times(1)).deactivateAllActive();
-            verify(termsVersionRepository, times(1)).activateById(termsVersionId);
+            verify(termsVersionRepository, times(1)).switchActiveById(termsVersionId);
         }
 
         @Test
@@ -82,8 +80,7 @@ class ActivateTermsVersionImplTest extends UnitTestAbstract {
             activateTermsVersion.activate(termsVersionId);
 
             verify(findTermsVersion, times(1)).findById(termsVersionId);
-            verify(termsVersionRepository, never()).deactivateAllActive();
-            verify(termsVersionRepository, never()).activateById(termsVersionId);
+            verify(termsVersionRepository, never()).switchActiveById(termsVersionId);
         }
     }
 
@@ -108,8 +105,7 @@ class ActivateTermsVersionImplTest extends UnitTestAbstract {
                 );
 
             verify(findTermsVersion, times(1)).findById(nonExistentId);
-            verify(termsVersionRepository, never()).deactivateAllActive();
-            verify(termsVersionRepository, never()).activateById(nonExistentId);
+            verify(termsVersionRepository, never()).switchActiveById(nonExistentId);
         }
     }
 }

--- a/src/test/java/com/buddy/api/units/domains/services/impl/CreateTermsVersionImplTest.java
+++ b/src/test/java/com/buddy/api/units/domains/services/impl/CreateTermsVersionImplTest.java
@@ -20,6 +20,7 @@ import com.buddy.api.domains.terms.dtos.TermsVersionDto;
 import com.buddy.api.domains.terms.entities.TermsVersionEntity;
 import com.buddy.api.domains.terms.mappers.TermsMapper;
 import com.buddy.api.domains.terms.repositories.TermsVersionRepository;
+import com.buddy.api.domains.terms.services.ActivateTermsVersion;
 import com.buddy.api.domains.terms.services.FindTermsVersion;
 import com.buddy.api.domains.terms.services.impl.CreateTermsVersionImpl;
 import com.buddy.api.domains.valueobjects.EmailAddress;
@@ -47,6 +48,9 @@ class CreateTermsVersionImplTest extends UnitTestAbstract {
     @Mock
     private FindTermsVersion findTermsVersion;
 
+    @Mock
+    private ActivateTermsVersion activateTermsVersion;
+
     @Spy
     private TermsMapper termsMapper = Mappers.getMapper(TermsMapper.class);
 
@@ -58,7 +62,7 @@ class CreateTermsVersionImplTest extends UnitTestAbstract {
     class SuccessScenarios {
 
         @Test
-        @DisplayName("Should create version successfully when input is valid and isActive is true")
+        @DisplayName("Should create version as draft and call activate when isActive is true")
         void should_create_version_when_valid_input_and_active() {
             final String adminEmail = RandomEmailUtils.generateValidEmail();
             final CreateTermsVersionDto dto = validCreateTermsVersionDto()
@@ -73,7 +77,7 @@ class CreateTermsVersionImplTest extends UnitTestAbstract {
             final TermsVersionEntity entityToSave = TermsVersionEntity.builder()
                 .versionTag(dto.versionTag())
                 .content(dto.content())
-                .isActive(true)
+                .isActive(false)
                 .publicationDate(LocalDate.now())
                 .publishedBy(AccountEntity.builder().accountId(publisherDto.accountId()).build())
                 .build();
@@ -82,31 +86,30 @@ class CreateTermsVersionImplTest extends UnitTestAbstract {
                 .termsVersionId(UUID.randomUUID())
                 .versionTag(dto.versionTag())
                 .content(dto.content())
-                .isActive(true)
+                .isActive(false)
                 .publicationDate(LocalDate.now())
                 .publishedBy(AccountEntity.builder().accountId(publisherDto.accountId()).build())
                 .build();
 
             when(findTermsVersion.findByTag(dto.versionTag())).thenReturn(Optional.empty());
             when(findAccount.findByEmail(adminEmail)).thenReturn(publisherDto);
-            when(termsVersionRepository.deactivateAllActive()).thenReturn(1);
             when(termsVersionRepository.save(entityToSave)).thenReturn(savedEntity);
 
             final var result = createTermsVersion.create(dto);
 
             assertThat(result).isNotNull();
             assertThat(result.versionTag()).isEqualTo(dto.versionTag());
-            assertThat(result.content()).isEqualTo(dto.content());
             assertThat(result.isActive()).isTrue();
 
             verify(findTermsVersion, times(1)).findByTag(dto.versionTag());
             verify(findAccount, times(1)).findByEmail(adminEmail);
-            verify(termsVersionRepository, times(1)).deactivateAllActive();
             verify(termsVersionRepository, times(1)).save(entityToSave);
+
+            verify(activateTermsVersion, times(1)).activate(savedEntity.getTermsVersionId());
         }
 
         @Test
-        @DisplayName("Should create version without deactivating when isActive is false")
+        @DisplayName("Should create version without calling activate when isActive is false")
         void should_create_version_without_deactivating_when_inactive() {
             final String adminEmail = RandomEmailUtils.generateValidEmail();
             final CreateTermsVersionDto dto = validCreateTermsVersionDto()
@@ -144,8 +147,8 @@ class CreateTermsVersionImplTest extends UnitTestAbstract {
             assertThat(result).isNotNull();
             assertThat(result.isActive()).isFalse();
 
-            verify(termsVersionRepository, never()).deactivateAllActive();
             verify(termsVersionRepository, times(1)).save(entityToSave);
+            verify(activateTermsVersion, never()).activate(any());
         }
     }
 

--- a/src/test/java/com/buddy/api/units/domains/services/impl/FindTermsVersionTest.java
+++ b/src/test/java/com/buddy/api/units/domains/services/impl/FindTermsVersionTest.java
@@ -16,6 +16,7 @@ import com.buddy.api.domains.terms.repositories.TermsVersionRepository;
 import com.buddy.api.domains.terms.services.impl.FindTermsVersionImpl;
 import com.buddy.api.units.UnitTestAbstract;
 import java.util.Optional;
+import java.util.UUID;
 import org.apache.commons.lang3.RandomStringUtils;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -72,6 +73,49 @@ class FindTermsVersionTest extends UnitTestAbstract {
 
         verify(termsVersionRepository,
             times(1)).findFirstByIsActiveTrueOrderByPublicationDateDesc();
+    }
+
+    @Test
+    @DisplayName("Should return terms version DTO when found by id")
+    void should_return_dto_when_found_by_id() {
+        final UUID termsVersionId = UUID.randomUUID();
+        final TermsVersionEntity entity = validTermsVersionEntity()
+            .termsVersionId(termsVersionId)
+            .build();
+
+        when(termsVersionRepository.findById(termsVersionId))
+            .thenReturn(Optional.of(entity));
+
+        final var result = findTermsVersion.findById(termsVersionId);
+
+        assertThat(result)
+            .isNotNull()
+            .satisfies(dto -> {
+                assertThat(dto.termsVersionId()).isEqualTo(termsVersionId);
+                assertThat(dto.versionTag()).isEqualTo(entity.getVersionTag());
+                assertThat(dto.content()).isEqualTo(entity.getContent());
+                assertThat(dto.isActive()).isEqualTo(entity.getIsActive());
+            });
+
+        verify(termsVersionRepository, times(1)).findById(termsVersionId);
+        verify(termsMapper, times(1)).toTermsVersionDto(entity);
+    }
+
+    @Test
+    @DisplayName("Should throw NotFoundException when terms version is not found by id")
+    void should_throw_exception_when_not_found_by_id() {
+        final UUID nonExistentId = UUID.randomUUID();
+
+        when(termsVersionRepository.findById(nonExistentId))
+            .thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> findTermsVersion.findById(nonExistentId))
+            .isInstanceOf(NotFoundException.class)
+            .hasMessageContaining("Terms version not found with id: " + nonExistentId)
+            .hasFieldOrPropertyWithValue("fieldName", "termsVersionId");
+
+        verify(termsVersionRepository, times(1)).findById(nonExistentId);
+        verify(termsMapper, never()).toTermsVersionDto(any());
     }
 
     @Test


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Novo endpoint PATCH para ativar uma versão específica dos Termos de Uso (somente administradores); ativa a versão indicada e desativa a anterior.

* **Documentation**
  * Documentação OpenAPI atualizada para o novo endpoint de ativação.

* **Tests**
  * Testes de integração e unitários cobrindo sucesso, idempotência, erros (404) e cenários de autorização.

* **Refactor**
  * Removido suporte à serialização de uma classe de exceção.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->